### PR TITLE
Add useful diff representation of Time-like values

### DIFF
--- a/lib/super_diff/differs.rb
+++ b/lib/super_diff/differs.rb
@@ -7,10 +7,12 @@ module SuperDiff
     autoload :Empty, "super_diff/differs/empty"
     autoload :Hash, "super_diff/differs/hash"
     autoload :MultilineString, "super_diff/differs/multiline_string"
+    autoload :Time, "super_diff/differs/time"
 
     DEFAULTS = [
       Array,
       Hash,
+      Time,
       MultilineString,
       CustomObject,
       DefaultObject,

--- a/lib/super_diff/differs/time.rb
+++ b/lib/super_diff/differs/time.rb
@@ -1,0 +1,24 @@
+module SuperDiff
+  module Differs
+    class Time < Base
+      def self.applies_to?(expected, actual)
+        OperationalSequencers::TimeLike.applies_to?(expected, actual)
+      end
+
+      def call
+        operations.to_diff(indent_level: indent_level)
+      end
+
+      private
+
+      def operations
+        OperationalSequencers::TimeLike.call(
+          expected: expected,
+          actual: actual,
+          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
+          extra_diff_formatter_classes: extra_diff_formatter_classes,
+        )
+      end
+    end
+  end
+end

--- a/lib/super_diff/object_inspection/inspectors.rb
+++ b/lib/super_diff/object_inspection/inspectors.rb
@@ -13,6 +13,7 @@ module SuperDiff
       autoload :Hash, "super_diff/object_inspection/inspectors/hash"
       autoload :Primitive, "super_diff/object_inspection/inspectors/primitive"
       autoload :String, "super_diff/object_inspection/inspectors/string"
+      autoload :Time, "super_diff/object_inspection/inspectors/time"
     end
   end
 end

--- a/lib/super_diff/object_inspection/inspectors/time.rb
+++ b/lib/super_diff/object_inspection/inspectors/time.rb
@@ -1,0 +1,13 @@
+module SuperDiff
+  module ObjectInspection
+    module Inspectors
+      TIME_FORMAT = "%Y-%m-%d %H:%M:%S.%3N %Z %:z".freeze
+
+      Time = InspectionTree.new do
+        add_text do |time|
+          "#{time.strftime(TIME_FORMAT)} (#{time.class})"
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/object_inspection/map.rb
+++ b/lib/super_diff/object_inspection/map.rb
@@ -16,6 +16,8 @@ module SuperDiff
             Inspectors::Hash
           when String
             Inspectors::String
+          when Time
+            Inspectors::Time
           when true, false, nil, Symbol, Numeric, Regexp, Class
             Inspectors::Primitive
           else

--- a/lib/super_diff/operational_sequencers.rb
+++ b/lib/super_diff/operational_sequencers.rb
@@ -10,6 +10,7 @@ module SuperDiff
       :MultilineString,
       "super_diff/operational_sequencers/multiline_string",
     )
+    autoload :TimeLike, "super_diff/operational_sequencers/time_like"
 
     DEFAULTS = [Array, Hash, CustomObject].freeze
   end

--- a/lib/super_diff/operational_sequencers/time_like.rb
+++ b/lib/super_diff/operational_sequencers/time_like.rb
@@ -14,7 +14,16 @@ module SuperDiff
       protected
 
       def attribute_names
-        ["year", "month", "day", "hour", "min", "sec", "nsec", "zone", "gmt_offset"]
+        base = ["year", "month", "day", "hour", "min", "sec", "nsec", "zone", "gmt_offset"]
+
+        # If timezones are different, also show a normalized timestamp at the
+        # end of the diff to help visualize why they are different moments in
+        # time.
+        if actual.zone != expected.zone
+          base + ["utc"]
+        else
+          base
+        end
       end
     end
   end

--- a/lib/super_diff/operational_sequencers/time_like.rb
+++ b/lib/super_diff/operational_sequencers/time_like.rb
@@ -1,0 +1,21 @@
+module SuperDiff
+  module OperationalSequencers
+    class TimeLike < CustomObject
+      def self.applies_to?(expected, actual)
+        (expected.is_a?(Time) && actual.is_a?(Time)) ||
+          (
+            # Check for ActiveSupport's #acts_like_time? for their time-like objects
+            # (like ActiveSupport::TimeWithZone).
+            expected.respond_to?(:acts_like_time?) && expected.acts_like_time? &&
+            actual.respond_to?(:acts_like_time?) && actual.acts_like_time?
+          )
+      end
+
+      protected
+
+      def attribute_names
+        ["year", "month", "day", "hour", "min", "sec", "nsec", "zone", "gmt_offset"]
+      end
+    end
+  end
+end

--- a/spec/integration/rspec/eq_matcher_spec.rb
+++ b/spec/integration/rspec/eq_matcher_spec.rb
@@ -290,8 +290,10 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             plain_line "    nsec: 0,"
             alpha_line "-   zone: \"CET\","
             beta_line  "+   zone: \"UTC\","
-            alpha_line "-   gmt_offset: 3600"
-            beta_line  "+   gmt_offset: 0"
+            alpha_line "-   gmt_offset: 3600,"
+            beta_line  "+   gmt_offset: 0,"
+            alpha_line "-   utc: 2011-12-13 15:15:16.000 UTC +00:00 (Time)"
+            beta_line  "+   utc: 2011-12-13 14:15:16.000 UTC +00:00 (Time)"
             plain_line "  }>"
           },
         )


### PR DESCRIPTION
This should add a more useful diff for `Time` instances, as well as make the diff output from `ActiveSupport::TimeWithZone` instances readable.

Previously the `ActiveSupport::TimeWithZone` diff output would contain all the timezones, leading to several thousand lines in the diff. Now all time-like instances will work the same way: Single-line diffs will be of a simple ISO-like string, while the full diff will show which parts of the time actually differs.

Timezone is promptly shown, both with name and with GMT offset.

This should fix #52.

## Screenshots

### Before

#### `Time` vs `Time`

![Screenshot 2019-11-20 15:08:01](https://user-images.githubusercontent.com/1599/69245803-cf162380-0ba7-11ea-9378-e55b24b42d6f.png)


#### `Time` vs `ActiveSupport::TimeWithZone`

![Screenshot 2019-11-20 15:08:44](https://user-images.githubusercontent.com/1599/69245828-dc331280-0ba7-11ea-8f6e-332466a452c1.png)


### After

#### `Time` vs `Time`

![Screenshot 2019-11-20 15:07:02](https://user-images.githubusercontent.com/1599/69245813-d4736e00-0ba7-11ea-852d-509f422a5044.png)

#### `Time` vs `ActiveSupport::TimeWithZone`

![Screenshot 2019-11-20 15:08:52](https://user-images.githubusercontent.com/1599/69245837-e05f3000-0ba7-11ea-9b63-2ac2a57e5542.png)

