### PR TITLE
Fix tests so they run even with a global --color setting

### DIFF
--- a/spec/support/integration/matchers/produce_output_when_run_matcher.rb
+++ b/spec/support/integration/matchers/produce_output_when_run_matcher.rb
@@ -89,7 +89,7 @@ module SuperDiff
 
       def run_command
         CommandRunner.run(
-          "rspec",
+          "rspec --options /tmp/dummy-rspec-config",
           tempfile.to_s,
           env: { "DISABLE_PRY" => "true" },
         )


### PR DESCRIPTION
If you have global RSpec settings located at `~/.rspec`, and you have
`--color` as one of your settings, and you try to run the `super_diff`
tests locally, the integration tests, which ensure that output is
printed in the correct colors and which work by spawning a new `rspec`
child process for each test, will fail. I'm not exactly sure why this is
happening, but we can get around this by instructing the child `rspec`
process not to use the global configuration settings.