### PR TITLE
Initialize failure line groups as array. Issue #56

### DIFF
--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -91,10 +91,12 @@ module RSpec
           @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
           # Patch to convert options[:failure_lines] to groups
           if options.include?(:failure_lines)
-            @failure_line_groups = {
-              lines: options[:failure_lines],
-              already_colorized: false
-            }
+            @failure_line_groups = [
+              {
+                lines: options[:failure_lines],
+                already_colorized: false
+              }
+            ]
           end
         end
 

--- a/spec/integration/rspec/unhandled_errors_spec.rb
+++ b/spec/integration/rspec/unhandled_errors_spec.rb
@@ -66,4 +66,25 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
       end
     end
   end
+
+  context "when multiple exception occur" do
+    it "highlights the first line in red, and then leaves the rest of the message alone" do
+      as_both_colored_and_uncolored do |color_enabled|
+        program = <<~PROGRAM.strip
+          #{set_up_with("super_diff/rspec", color_enabled: color_enabled)}
+          RSpec.describe "test" do
+            after(:each) do
+              raise "Some kind of after error or whatever\\n\\nThis is another line"
+            end
+            it "passes" do
+              raise "Some kind of error or whatever\\n\\nThis is another line"
+            end
+          end
+        PROGRAM
+
+        expect(program).
+          to produce_output_when_run('Some kind of after error or whatever')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Failure line groups should be initialized as array in case of Rspec's ExceptionPresenter.

Fixes #56 issue.