### PR TITLE
Add testing with Ruby 2.7 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ gemfile:
   - gemfiles/no_rails.gemfile
 matrix:
   exclude:
-    - rvm: ruby-2.4.6
+    - rvm: 2.4
       gemfile: gemfiles/rails_6_0.gemfile
 rvm:
-  - ruby-2.6.3
-  - ruby-2.5.5
-  - ruby-2.4.6
+  - 2.7
+  - 2.6
+  - 2.5
+  - 2.4
   #- jruby-9.2.7.0


### PR DESCRIPTION
I took the liberty to simplify the list of rubies. This should select the latest available Ruby version of each minor version on Travis CI.