### PR TITLE
Correct expected message for raise_error with regexp. Issue #72

### DIFF
--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -661,7 +661,9 @@ module RSpec
 
           def expected_for_matcher_text
             if @expected_message
-              "#<#{@expected_error.name} #{@expected_message.inspect}>"
+              "#<#{@expected_error.name} #{description_of(@expected_message)}>"
+            elsif @expected_error.is_a? Regexp
+              "#<Exception #{description_of(@expected_error)}>"
             else
               "#<#{@expected_error.name}>"
             end

--- a/spec/unit/rspec/matchers/raise_error_spec.rb
+++ b/spec/unit/rspec/matchers/raise_error_spec.rb
@@ -18,10 +18,26 @@ RSpec.describe "RSpec's `raise_error` matcher" do
       end
     end
 
+    context "with regular expression as message (and assuming a RuntimeError)" do
+      it "returns the correct output" do
+        expect(raise_error(/hell/).description).to eq(
+          %|raise error #<Exception /hell/>|,
+        )
+      end
+    end
+
     context "with both an exception and a message" do
       it "returns the correct output" do
         expect(raise_error(RuntimeError, "hell").description).to eq(
           %|raise error #<RuntimeError "hell">|,
+        )
+      end
+    end
+
+    context "with an exception and a regular expression as message" do
+      it "returns the correct output" do
+        expect(raise_error(RuntimeError, /hell/).description).to eq(
+          %|raise error #<RuntimeError /hell/>|,
         )
       end
     end


### PR DESCRIPTION
Fixes the error when regex used in `raise_error` by adding a description for that type of expectation.