### PR TITLE
Add inspectors for more fuzzy matchers

### DIFF
--- a/lib/super_diff/object_inspection/inspection_tree.rb
+++ b/lib/super_diff/object_inspection/inspection_tree.rb
@@ -107,8 +107,12 @@ module SuperDiff
         end
       end
 
-      def add_inspection_of(value)
-        add_node :inspection, value
+      def add_inspection_of(value = nil, &block)
+        if block
+          add_node :inspection, &block
+        else
+          add_node :inspection, value
+        end
       end
 
       def apply_tree(tree)

--- a/lib/super_diff/object_inspection/nodes/inspection.rb
+++ b/lib/super_diff/object_inspection/nodes/inspection.rb
@@ -2,9 +2,16 @@ module SuperDiff
   module ObjectInspection
     module Nodes
       class Inspection < Base
-        def evaluate(_object, indent_level:, as_single_line:)
+        def evaluate(object, indent_level:, as_single_line:)
+          value =
+            if block
+              tree.evaluate_block(object, &block)
+            else
+              immediate_value
+            end
+
           SuperDiff::ObjectInspection.inspect(
-            immediate_value,
+            value,
             indent_level: indent_level,
             as_single_line: as_single_line,
           )

--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -48,6 +48,21 @@ module SuperDiff
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::ContainExactly)
     end
 
+    def self.a_kind_of_something?(value)
+      fuzzy_object?(value) &&
+        value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeAKindOf)
+    end
+
+    def self.an_instance_of_something?(value)
+      fuzzy_object?(value) &&
+        value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeAnInstanceOf)
+    end
+
+    def self.a_value_within_something?(value)
+      fuzzy_object?(value) &&
+        value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeWithin)
+    end
+
     def self.fuzzy_object?(value)
       value.is_a?(::RSpec::Matchers::AliasedMatcher)
     end

--- a/lib/super_diff/rspec/object_inspection/inspectors.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors.rb
@@ -15,8 +15,20 @@ module SuperDiff
           "super_diff/rspec/object_inspection/inspectors/hash_including",
         )
         autoload(
+          :InstanceOf,
+          "super_diff/rspec/object_inspection/inspectors/instance_of",
+        )
+        autoload(
+          :KindOf,
+          "super_diff/rspec/object_inspection/inspectors/kind_of",
+        )
+        autoload(
           :ObjectHavingAttributes,
           "super_diff/rspec/object_inspection/inspectors/object_having_attributes",
+        )
+        autoload(
+          :ValueWithin,
+          "super_diff/rspec/object_inspection/inspectors/value_within",
         )
       end
     end

--- a/lib/super_diff/rspec/object_inspection/inspectors/instance_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/instance_of.rb
@@ -1,0 +1,13 @@
+module SuperDiff
+  module RSpec
+    module ObjectInspection
+      module Inspectors
+        InstanceOf = SuperDiff::ObjectInspection::InspectionTree.new do
+          add_text do |aliased_matcher|
+            "#<an instance of #{aliased_matcher.expected}>"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/rspec/object_inspection/inspectors/kind_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/kind_of.rb
@@ -1,0 +1,13 @@
+module SuperDiff
+  module RSpec
+    module ObjectInspection
+      module Inspectors
+        KindOf = SuperDiff::ObjectInspection::InspectionTree.new do
+          add_text do |aliased_matcher|
+            "#<a kind of #{aliased_matcher.expected}>"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/rspec/object_inspection/inspectors/value_within.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/value_within.rb
@@ -1,0 +1,19 @@
+module SuperDiff
+  module RSpec
+    module ObjectInspection
+      module Inspectors
+        ValueWithin = SuperDiff::ObjectInspection::InspectionTree.new do
+          add_text "#<a value within "
+
+          add_inspection_of do |aliased_matcher|
+            aliased_matcher.base_matcher.instance_variable_get("@delta")
+          end
+
+          add_text " of "
+          add_inspection_of(&:expected)
+          add_text ">"
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/rspec/object_inspection/map_extension.rb
+++ b/lib/super_diff/rspec/object_inspection/map_extension.rb
@@ -11,6 +11,12 @@ module SuperDiff
             Inspectors::ObjectHavingAttributes
           elsif SuperDiff::RSpec.a_collection_containing_exactly_something?(object)
             Inspectors::CollectionContainingExactly
+          elsif SuperDiff::RSpec.a_kind_of_something?(object)
+            Inspectors::KindOf
+          elsif SuperDiff::RSpec.an_instance_of_something?(object)
+            Inspectors::InstanceOf
+          elsif SuperDiff::RSpec.a_value_within_something?(object)
+            Inspectors::ValueWithin
           elsif object.is_a?(::RSpec::Mocks::Double)
             SuperDiff::ObjectInspection::Inspectors::Primitive
           else

--- a/spec/unit/object_inspection_spec.rb
+++ b/spec/unit/object_inspection_spec.rb
@@ -601,7 +601,7 @@ RSpec.describe SuperDiff::ObjectInspection do
               as_single_line: false,
             )
             expect(inspection).to match(
-              /#<SuperDiff::Test::EmptyClass:0x[a-z0-9]+>/
+              /#<SuperDiff::Test::EmptyClass:0x[a-z0-9]+>/,
             )
           end
         end
@@ -730,6 +730,82 @@ RSpec.describe SuperDiff::ObjectInspection do
               "baz"
             )>
           INSPECTION
+        end
+      end
+    end
+
+    context "given a kind-of-<something>" do
+      context "given as_single_line: true" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            a_kind_of(Symbol),
+            as_single_line: true,
+          )
+
+          expect(inspection).to eq(%(#<a kind of Symbol>))
+        end
+      end
+
+      context "given as_single_line: false" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            a_kind_of(Symbol),
+            as_single_line: false,
+          )
+
+          expect(inspection).to eq(%(#<a kind of Symbol>))
+        end
+      end
+    end
+
+    context "given an-instance-of-<something>" do
+      context "given as_single_line: true" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            an_instance_of(Symbol),
+            as_single_line: true,
+          )
+
+          expect(inspection).to eq(%(#<an instance of Symbol>))
+        end
+      end
+
+      context "given as_single_line: false" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            an_instance_of(Symbol),
+            as_single_line: false,
+          )
+
+          expect(inspection).to eq(%(#<an instance of Symbol>))
+        end
+      end
+    end
+
+    context "given a-value-within-<something>" do
+      context "given as_single_line: true" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            a_value_within(1).of(Time.utc(2020, 4, 9)),
+            as_single_line: true,
+          )
+
+          expect(inspection).to eq(
+            %(#<a value within 1 of 2020-04-09 00:00:00.000 UTC +00:00 (Time)>),
+          )
+        end
+      end
+
+      context "given as_single_line: false" do
+        it "returns a representation of the object on a single line" do
+          inspection = described_class.inspect(
+            a_value_within(1).of(Time.utc(2020, 4, 9)),
+            as_single_line: false,
+          )
+
+          expect(inspection).to eq(
+            %(#<a value within 1 of 2020-04-09 00:00:00.000 UTC +00:00 (Time)>),
+          )
         end
       end
     end


### PR DESCRIPTION
Ensure that these fuzzy matcher objects are inspected in diff output:

* `an_instance_of(...)`
* `a_kind_of(...)`
* `a_value_within(...).of(...)`