### PR TITLE
Fix diff from using have_attributes with a hash

### DIFF
--- a/lib/super_diff.rb
+++ b/lib/super_diff.rb
@@ -15,15 +15,21 @@ module SuperDiff
   autoload :EqualityMatcher, "super_diff/equality_matcher"
   autoload :EqualityMatchers, "super_diff/equality_matchers"
   autoload :Helpers, "super_diff/helpers"
+  autoload :ImplementationChecks, "super_diff/implementation_checks"
   autoload :NoDifferAvailableError, "super_diff/no_differ_available_error"
+  autoload(
+    :NoDiffFormatterAvailableError,
+    "super_diff/no_diff_formatter_available_error",
+  )
   autoload(
     :NoOperationalSequencerAvailableError,
     "super_diff/no_operational_sequencer_available_error",
   )
   autoload :ObjectInspection, "super_diff/object_inspection"
+  autoload :OperationSequence, "super_diff/operation_sequence"
+  autoload :OperationSequences, "super_diff/operation_sequences"
   autoload :OperationalSequencer, "super_diff/operational_sequencer"
   autoload :OperationalSequencers, "super_diff/operational_sequencers"
-  autoload :OperationSequences, "super_diff/operation_sequences"
   autoload :Operations, "super_diff/operations"
   autoload :RecursionGuard, "super_diff/recursion_guard"
 

--- a/lib/super_diff/diff_formatter.rb
+++ b/lib/super_diff/diff_formatter.rb
@@ -7,16 +7,22 @@ module SuperDiff
       [
         :indent_level!,
         add_comma: false,
+        value_class: nil,
         extra_classes: [],
       ],
     )
 
     def call
-      resolved_class.call(
-        operations,
-        indent_level: indent_level,
-        add_comma: add_comma?,
-      )
+      if resolved_class
+        resolved_class.call(
+          operations,
+          indent_level: indent_level,
+          add_comma: add_comma?,
+          value_class: value_class
+        )
+      else
+        raise NoDiffFormatterAvailableError.create(operations)
+      end
     end
 
     private
@@ -24,9 +30,11 @@ module SuperDiff
     attr_query :add_comma?
 
     def resolved_class
-      (DiffFormatters::DEFAULTS + extra_classes).find do |klass|
-        klass.applies_to?(operations)
-      end
+      available_classes.find { |klass| klass.applies_to?(operations) }
+    end
+
+    def available_classes
+      DiffFormatters::DEFAULTS + extra_classes
     end
   end
 end

--- a/lib/super_diff/diff_formatters.rb
+++ b/lib/super_diff/diff_formatters.rb
@@ -8,7 +8,11 @@ module SuperDiff
     autoload :Hash, "super_diff/diff_formatters/hash"
     autoload :MultilineString, "super_diff/diff_formatters/multiline_string"
 
-    # TODO: Why doesn't this include CustomObject and DefaultObject?
-    DEFAULTS = [Array, Hash, MultilineString].freeze
+    DEFAULTS = [
+      Array,
+      Hash,
+      CustomObject,
+      DefaultObject,
+    ].freeze
   end
 end

--- a/lib/super_diff/diff_formatters/base.rb
+++ b/lib/super_diff/diff_formatters/base.rb
@@ -5,6 +5,7 @@ module SuperDiff
         raise NotImplementedError
       end
 
+      include ImplementationChecks
       extend AttrExtras.mixin
 
       method_object(

--- a/lib/super_diff/diff_formatters/default_object.rb
+++ b/lib/super_diff/diff_formatters/default_object.rb
@@ -38,9 +38,7 @@ module SuperDiff
         if @value_class
           @value_class
         else
-          raise NotImplementedError.new(
-            "You must override #value_class in your subclass.",
-          )
+          unimplemented_instance_method!
         end
       end
     end

--- a/lib/super_diff/differ.rb
+++ b/lib/super_diff/differ.rb
@@ -10,6 +10,7 @@ module SuperDiff
         index_in_collection: nil,
         omit_empty: false,
         extra_classes: [],
+        extra_operation_sequence_classes: [],
         extra_operational_sequencer_classes: [],
         extra_diff_formatter_classes: [],
       ],
@@ -22,6 +23,7 @@ module SuperDiff
           actual,
           indent_level: indent_level,
           index_in_collection: index_in_collection,
+          extra_operation_sequence_classes: extra_operation_sequence_classes,
           extra_operational_sequencer_classes: extra_operational_sequencer_classes,
           extra_diff_formatter_classes: extra_diff_formatter_classes,
         )

--- a/lib/super_diff/differs/array.rb
+++ b/lib/super_diff/differs/array.rb
@@ -5,19 +5,10 @@ module SuperDiff
         expected.is_a?(::Array) && actual.is_a?(::Array)
       end
 
-      def call
-        DiffFormatters::Array.call(operations, indent_level: indent_level)
-      end
-
       private
 
-      def operations
-        OperationalSequencers::Array.call(
-          expected: expected,
-          actual: actual,
-          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-          extra_diff_formatter_classes: extra_diff_formatter_classes,
-        )
+      def operational_sequencer_class
+        OperationalSequencers::Array
       end
     end
   end

--- a/lib/super_diff/differs/base.rb
+++ b/lib/super_diff/differs/base.rb
@@ -5,7 +5,9 @@ module SuperDiff
         raise NotImplementedError
       end
 
+      extend ImplementationChecks
       extend AttrExtras.mixin
+      include ImplementationChecks
 
       method_object(
         :expected,
@@ -13,19 +15,40 @@ module SuperDiff
         [
           :indent_level!,
           index_in_collection: nil,
+          extra_operation_sequence_classes: [],
           extra_operational_sequencer_classes: [],
           extra_diff_formatter_classes: [],
         ],
       )
 
       def call
-        raise NotImplementedError
+        operations.to_diff(
+          indent_level: indent_level,
+          collection_prefix: nil,
+          add_comma: false,
+        )
       end
 
       protected
 
       def indentation
         " " * (indent_level * 2)
+      end
+
+      def operational_sequencer_class
+        unimplemented_instance_method!
+      end
+
+      private
+
+      def operations
+        operational_sequencer_class.call(
+          expected: expected,
+          actual: actual,
+          extra_operation_sequence_classes: extra_operation_sequence_classes,
+          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
+          extra_diff_formatter_classes: extra_diff_formatter_classes,
+        )
       end
     end
   end

--- a/lib/super_diff/differs/custom_object.rb
+++ b/lib/super_diff/differs/custom_object.rb
@@ -7,19 +7,10 @@ module SuperDiff
           actual.respond_to?(:attributes_for_super_diff)
       end
 
-      def call
-        operations.to_diff(indent_level: indent_level)
-      end
-
       private
 
-      def operations
-        OperationalSequencers::CustomObject.call(
-          expected: expected,
-          actual: actual,
-          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-          extra_diff_formatter_classes: extra_diff_formatter_classes,
-        )
+      def operational_sequencer_class
+        OperationalSequencers::CustomObject
       end
     end
   end

--- a/lib/super_diff/differs/default_object.rb
+++ b/lib/super_diff/differs/default_object.rb
@@ -5,10 +5,6 @@ module SuperDiff
         expected.class == actual.class
       end
 
-      def call
-        operations.to_diff(indent_level: indent_level)
-      end
-
       private
 
       def operations
@@ -16,6 +12,7 @@ module SuperDiff
           expected: expected,
           actual: actual,
           all_or_nothing: true,
+          extra_operation_sequence_classes: extra_operation_sequence_classes,
           extra_classes: extra_operational_sequencer_classes,
           extra_diff_formatter_classes: extra_diff_formatter_classes,
         )

--- a/lib/super_diff/differs/hash.rb
+++ b/lib/super_diff/differs/hash.rb
@@ -5,19 +5,10 @@ module SuperDiff
         expected.is_a?(::Hash) && actual.is_a?(::Hash)
       end
 
-      def call
-        DiffFormatters::Hash.call(operations, indent_level: indent_level)
-      end
-
       private
 
-      def operations
-        OperationalSequencers::Hash.call(
-          expected: expected,
-          actual: actual,
-          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-          extra_diff_formatter_classes: extra_diff_formatter_classes,
-        )
+      def operational_sequencer_class
+        OperationalSequencers::Hash
       end
     end
   end

--- a/lib/super_diff/differs/multiline_string.rb
+++ b/lib/super_diff/differs/multiline_string.rb
@@ -6,22 +6,10 @@ module SuperDiff
           (expected.include?("\n") || actual.include?("\n"))
       end
 
-      def call
-        DiffFormatters::MultilineString.call(
-          operations,
-          indent_level: indent_level,
-        )
-      end
-
       private
 
-      def operations
-        OperationalSequencers::MultilineString.call(
-          expected: expected,
-          actual: actual,
-          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-          extra_diff_formatter_classes: extra_diff_formatter_classes,
-        )
+      def operational_sequencer_class
+        OperationalSequencers::MultilineString
       end
     end
   end

--- a/lib/super_diff/differs/time.rb
+++ b/lib/super_diff/differs/time.rb
@@ -5,19 +5,10 @@ module SuperDiff
         OperationalSequencers::TimeLike.applies_to?(expected, actual)
       end
 
-      def call
-        operations.to_diff(indent_level: indent_level)
-      end
-
       private
 
-      def operations
-        OperationalSequencers::TimeLike.call(
-          expected: expected,
-          actual: actual,
-          extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-          extra_diff_formatter_classes: extra_diff_formatter_classes,
-        )
+      def operational_sequencer_class
+        OperationalSequencers::TimeLike
       end
     end
   end

--- a/lib/super_diff/implementation_checks.rb
+++ b/lib/super_diff/implementation_checks.rb
@@ -1,0 +1,19 @@
+module SuperDiff
+  module ImplementationChecks
+    protected def unimplemented_instance_method!
+      raise(
+        NotImplementedError,
+        "#{self.class} must implement ##{caller_locations(1, 1).first.label}",
+        caller(1),
+      )
+    end
+
+    protected def unimplemented_class_method!
+      raise(
+        NotImplementedError,
+        "#{self} must implement .#{caller_locations(1, 1).first.label}",
+        caller(1),
+      )
+    end
+  end
+end

--- a/lib/super_diff/no_diff_formatter_available_error.rb
+++ b/lib/super_diff/no_diff_formatter_available_error.rb
@@ -1,0 +1,19 @@
+module SuperDiff
+  class NoDiffFormatterAvailableError < StandardError
+    def self.create(operations)
+      allocate.tap do |error|
+        error.operations = operations
+        error.__send__(:initialize)
+      end
+    end
+
+    attr_accessor :operations
+
+    def initialize
+      super(<<-MESSAGE)
+There is no diff formatter available to handle an operations object of
+#{operations.class}.
+      MESSAGE
+    end
+  end
+end

--- a/lib/super_diff/operation_sequence.rb
+++ b/lib/super_diff/operation_sequence.rb
@@ -1,0 +1,33 @@
+module SuperDiff
+  class OperationSequence
+    extend AttrExtras.mixin
+
+    method_object :value, [extra_classes: []]
+
+    def call
+      if resolved_class
+        begin
+          resolved_class.new([], value_class: value.class)
+        rescue ArgumentError
+          resolved_class.new([])
+        end
+      else
+        raise NoOperationalSequenceAvailableError.create(value)
+      end
+    end
+
+    private
+
+    def resolved_class
+      if value.respond_to?(:attributes_for_super_diff)
+        OperationSequences::CustomObject
+      else
+        available_classes.find { |klass| klass.applies_to?(value) }
+      end
+    end
+
+    def available_classes
+      extra_classes + OperationSequences::DEFAULTS
+    end
+  end
+end

--- a/lib/super_diff/operation_sequences.rb
+++ b/lib/super_diff/operation_sequences.rb
@@ -5,5 +5,8 @@ module SuperDiff
     autoload :CustomObject, "super_diff/operation_sequences/custom_object"
     autoload :DefaultObject, "super_diff/operation_sequences/default_object"
     autoload :Hash, "super_diff/operation_sequences/hash"
+    autoload :MultilineString, "super_diff/operation_sequences/multiline_string"
+
+    DEFAULTS = [Array, Hash, CustomObject, DefaultObject].freeze
   end
 end

--- a/lib/super_diff/operation_sequences/array.rb
+++ b/lib/super_diff/operation_sequences/array.rb
@@ -1,6 +1,10 @@
 module SuperDiff
   module OperationSequences
     class Array < Base
+      def self.applies_to?(value)
+        value.is_a?(::Array)
+      end
+
       def to_diff(indent_level:, collection_prefix:, add_comma:)
         DiffFormatters::Array.call(
           self,

--- a/lib/super_diff/operation_sequences/base.rb
+++ b/lib/super_diff/operation_sequences/base.rb
@@ -1,6 +1,12 @@
 module SuperDiff
   module OperationSequences
     class Base < SimpleDelegator
+      def self.applies_to?(_value)
+        unimplemented_class_method!
+      end
+
+      extend ImplementationChecks
+
       # rubocop:disable Lint/UnusedMethodArgument
       def to_diff(indent_level:, add_comma: false, collection_prefix: nil)
         raise NotImplementedError

--- a/lib/super_diff/operation_sequences/custom_object.rb
+++ b/lib/super_diff/operation_sequences/custom_object.rb
@@ -1,6 +1,10 @@
 module SuperDiff
   module OperationSequences
     class CustomObject < DefaultObject
+      def self.applies_to?(value)
+        value.respond_to?(:attributes_for_super_diff)
+      end
+
       def to_diff(indent_level:, add_comma: false, collection_prefix: nil)
         DiffFormatters::CustomObject.call(
           self,

--- a/lib/super_diff/operation_sequences/default_object.rb
+++ b/lib/super_diff/operation_sequences/default_object.rb
@@ -1,25 +1,27 @@
 module SuperDiff
   module OperationSequences
     class DefaultObject < Base
+      def self.applies_to?(_value)
+        true
+      end
+
+      attr_reader :value_class
+
+      # TODO: Default this to collection.class?
       def initialize(collection, value_class:)
         super(collection)
 
         @value_class = value_class
       end
 
-      def to_diff(indent_level:, add_comma: false, collection_prefix: nil)
-        DiffFormatters::DefaultObject.call(
+      def to_diff(indent_level:, add_comma: false, **_rest)
+        DiffFormatter.call(
           self,
           indent_level: indent_level,
-          collection_prefix: collection_prefix,
           add_comma: add_comma,
           value_class: value_class,
         )
       end
-
-      private
-
-      attr_reader :value_class
     end
   end
 end

--- a/lib/super_diff/operation_sequences/multiline_string.rb
+++ b/lib/super_diff/operation_sequences/multiline_string.rb
@@ -1,12 +1,12 @@
 module SuperDiff
   module OperationSequences
-    class Hash < Base
+    class MultilineString < Base
       def self.applies_to?(value)
-        value.is_a?(::Hash)
+        value.is_a?(::String) && value.is_a?(::String)
       end
 
       def to_diff(indent_level:, collection_prefix:, add_comma:)
-        DiffFormatters::Hash.call(
+        DiffFormatters::MultilineString.call(
           self,
           indent_level: indent_level,
           collection_prefix: collection_prefix,

--- a/lib/super_diff/operational_sequencer.rb
+++ b/lib/super_diff/operational_sequencer.rb
@@ -7,6 +7,7 @@ module SuperDiff
         :expected!,
         :actual!,
         :all_or_nothing!,
+        extra_operation_sequence_classes: [],
         extra_classes: [],
         extra_diff_formatter_classes: [],
       ],
@@ -17,6 +18,7 @@ module SuperDiff
         resolved_class.call(
           expected: expected,
           actual: actual,
+          extra_operation_sequence_classes: extra_operation_sequence_classes,
           extra_operational_sequencer_classes: extra_classes,
           extra_diff_formatter_classes: extra_diff_formatter_classes,
         )

--- a/lib/super_diff/operational_sequencers/base.rb
+++ b/lib/super_diff/operational_sequencers/base.rb
@@ -11,6 +11,7 @@ module SuperDiff
         [
           :expected!,
           :actual!,
+          extra_operation_sequence_classes: [],
           extra_operational_sequencer_classes: [],
           extra_diff_formatter_classes: [],
         ],
@@ -18,7 +19,7 @@ module SuperDiff
 
       def call
         i = 0
-        operations = build_operation_sequencer
+        operations = build_operation_sequence
 
         while i < unary_operations.length
           operation = unary_operations[i]
@@ -51,11 +52,11 @@ module SuperDiff
       protected
 
       def unary_operations
-        raise NotImplementedError
+        SuperDiff.unimplemented_instance_method!
       end
 
-      def build_operation_sequencer
-        raise NotImplementedError
+      def build_operation_sequence
+        SuperDiff.unimplemented_instance_method!
       end
 
       private

--- a/lib/super_diff/operational_sequencers/custom_object.rb
+++ b/lib/super_diff/operational_sequencers/custom_object.rb
@@ -7,7 +7,7 @@ module SuperDiff
           actual.respond_to?(:attributes_for_super_diff)
       end
 
-      def build_operation_sequencer
+      def build_operation_sequence
         # XXX This assumes that `expected` and `actual` are the same
         OperationSequences::CustomObject.new([], value_class: expected.class)
       end

--- a/lib/super_diff/operational_sequencers/default_object.rb
+++ b/lib/super_diff/operational_sequencers/default_object.rb
@@ -22,9 +22,17 @@ module SuperDiff
         end
       end
 
-      def build_operation_sequencer
+      def build_operation_sequence
         # XXX This assumes that `expected` and `actual` are the same
+        # TODO: Does this need to be find_operation_sequence_for?
         OperationSequences::DefaultObject.new([], value_class: expected.class)
+      end
+
+      def find_operation_sequence_for(value)
+        OperationSequence.call(
+          value,
+          extra_classes: extra_operation_sequence_classes,
+        )
       end
 
       def attribute_names

--- a/lib/super_diff/operational_sequencers/hash.rb
+++ b/lib/super_diff/operational_sequencers/hash.rb
@@ -16,7 +16,7 @@ module SuperDiff
         end
       end
 
-      def build_operation_sequencer
+      def build_operation_sequence
         OperationSequences::Hash.new([])
       end
 

--- a/lib/super_diff/operational_sequencers/multiline_string.rb
+++ b/lib/super_diff/operational_sequencers/multiline_string.rb
@@ -30,8 +30,8 @@ module SuperDiff
         end
       end
 
-      def build_operation_sequencer
-        OperationSequences::Array.new([])
+      def build_operation_sequence
+        OperationSequences::MultilineString.new([])
       end
 
       private

--- a/lib/super_diff/rspec/configuration.rb
+++ b/lib/super_diff/rspec/configuration.rb
@@ -3,18 +3,25 @@ module SuperDiff
     class Configuration
       attr_reader(
         :extra_differ_classes,
+        :extra_operation_sequence_classes,
         :extra_operational_sequencer_classes,
         :extra_diff_formatter_classes,
       )
 
       def initialize
         @extra_differ_classes = [].freeze
+        @extra_operation_sequence_classes = [].freeze
         @extra_operational_sequencer_classes = [].freeze
         @extra_diff_formatter_classes = [].freeze
       end
 
       def add_extra_differ_class(klass)
         @extra_differ_classes = (@extra_differ_classes + [klass]).freeze
+      end
+
+      def add_extra_operation_sequence_class(klass)
+        @extra_operation_sequence_classes =
+          (@extra_operation_sequence_classes + [klass]).freeze
       end
 
       def add_extra_operational_sequencer_class(klass)

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -18,6 +18,9 @@ module SuperDiff
               Differs::HashIncluding,
               Differs::ObjectHavingAttributes,
             ],
+            extra_operation_sequence_classes: [
+              *RSpec.configuration.extra_operation_sequence_classes,
+            ],
             extra_operational_sequencer_classes: [
               *RSpec.configuration.extra_operational_sequencer_classes,
               OperationalSequencers::CollectionContainingExactly,
@@ -25,7 +28,9 @@ module SuperDiff
               OperationalSequencers::HashIncluding,
               OperationalSequencers::ObjectHavingAttributes,
             ],
-            extra_diff_formatter_classes: RSpec.configuration.extra_diff_formatter_classes,
+            extra_diff_formatter_classes: [
+              *RSpec.configuration.extra_diff_formatter_classes,
+            ],
           )
           "\n\n" + diff
         else

--- a/lib/super_diff/rspec/differs/collection_containing_exactly.rb
+++ b/lib/super_diff/rspec/differs/collection_containing_exactly.rb
@@ -9,13 +9,8 @@ module SuperDiff
 
         private
 
-        def operations
-          OperationalSequencers::CollectionContainingExactly.call(
-            expected: expected,
-            actual: actual,
-            extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-            extra_diff_formatter_classes: extra_diff_formatter_classes,
-          )
+        def operational_sequencer_class
+          OperationalSequencers::CollectionContainingExactly
         end
       end
     end

--- a/lib/super_diff/rspec/differs/collection_including.rb
+++ b/lib/super_diff/rspec/differs/collection_including.rb
@@ -9,13 +9,8 @@ module SuperDiff
 
         private
 
-        def operations
-          OperationalSequencers::CollectionIncluding.call(
-            expected: expected,
-            actual: actual,
-            extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-            extra_diff_formatter_classes: extra_diff_formatter_classes,
-          )
+        def operational_sequencer_class
+          OperationalSequencers::CollectionIncluding
         end
       end
     end

--- a/lib/super_diff/rspec/differs/hash_including.rb
+++ b/lib/super_diff/rspec/differs/hash_including.rb
@@ -9,13 +9,8 @@ module SuperDiff
 
         private
 
-        def operations
-          OperationalSequencers::HashIncluding.call(
-            expected: expected,
-            actual: actual,
-            extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-            extra_diff_formatter_classes: extra_diff_formatter_classes,
-          )
+        def operational_sequencer_class
+          OperationalSequencers::HashIncluding
         end
       end
     end

--- a/lib/super_diff/rspec/differs/object_having_attributes.rb
+++ b/lib/super_diff/rspec/differs/object_having_attributes.rb
@@ -8,13 +8,8 @@ module SuperDiff
 
         private
 
-        def operations
-          OperationalSequencers::ObjectHavingAttributes.call(
-            expected: expected,
-            actual: actual,
-            extra_operational_sequencer_classes: extra_operational_sequencer_classes,
-            extra_diff_formatter_classes: extra_diff_formatter_classes,
-          )
+        def operational_sequencer_class
+          OperationalSequencers::ObjectHavingAttributes
         end
       end
     end

--- a/lib/super_diff/rspec/operational_sequencers/collection_containing_exactly.rb
+++ b/lib/super_diff/rspec/operational_sequencers/collection_containing_exactly.rb
@@ -28,7 +28,7 @@ module SuperDiff
           operations
         end
 
-        def build_operation_sequencer
+        def build_operation_sequence
           OperationSequences::Array.new([])
         end
 

--- a/lib/super_diff/rspec/operational_sequencers/object_having_attributes.rb
+++ b/lib/super_diff/rspec/operational_sequencers/object_having_attributes.rb
@@ -8,12 +8,8 @@ module SuperDiff
 
         protected
 
-        def build_operation_sequencer
-          if actual.respond_to?(:attributes_for_super_diff)
-            OperationSequences::CustomObject.new([], value_class: actual.class)
-          else
-            OperationSequences::DefaultObject.new([], value_class: actual.class)
-          end
+        def build_operation_sequence
+          find_operation_sequence_for(actual)
         end
 
         def attribute_names

--- a/spec/integration/rspec/have_attributes_matcher_spec.rb
+++ b/spec/integration/rspec/have_attributes_matcher_spec.rb
@@ -1,298 +1,342 @@
 require "spec_helper"
 
 RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integration do
-  context "when given a small set of attributes" do
-    context "when all of the names are methods on the actual object" do
-      it "produces the correct output when used in the positive" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = { name: "b" }
-            actual = SuperDiff::Test::Person.new(name: "a", age: 9)
-            expect(actual).to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
+  context "when the actual value is an object" do
+    context "with a small set of attributes" do
+      context "when all of the names are methods on the actual object" do
+        it "produces the correct output when used in the positive" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = { name: "b" }
+              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              expect(actual).to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
 
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).to have_attributes(expected)|,
-            expectation: proc {
-              line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                plain " to have attributes "
-                alpha %|(name: "b")|
-                plain "."
-              end
-            },
-            diff: proc {
-              plain_line %|  #<SuperDiff::Test::Person {|
-              # alpha_line %|-   name: "b",|  # FIXME
-              alpha_line %|-   name: "b"|
-              beta_line  %|+   name: "a",|
-              plain_line %|    age: 9|
-              plain_line %|  }>|
-            },
-          )
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).to have_attributes(expected)|,
+              expectation: proc {
+                line do
+                  plain "Expected "
+                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain " to have attributes "
+                  alpha %|(name: "b")|
+                  plain "."
+                end
+              },
+              diff: proc {
+                plain_line %|  #<SuperDiff::Test::Person {|
+                # alpha_line %|-   name: "b",|  # FIXME
+                alpha_line %|-   name: "b"|
+                beta_line  %|+   name: "a",|
+                plain_line %|    age: 9|
+                plain_line %|  }>|
+              },
+            )
 
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
+        end
+
+        it "produces the correct output when used in the negative" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = { name: "a" }
+              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              expect(actual).not_to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
+
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).not_to have_attributes(expected)|,
+              expectation: proc {
+                line do
+                  plain "Expected "
+                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain " not to have attributes "
+                  alpha %|(name: "a")|
+                  plain "."
+                end
+              },
+            )
+
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
         end
       end
 
-      it "produces the correct output when used in the negative" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = { name: "a" }
-            actual = SuperDiff::Test::Person.new(name: "a", age: 9)
-            expect(actual).not_to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
+      context "when some of the names are not methods on the actual object" do
+        it "produces the correct output" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = { name: "b", foo: "bar" }
+              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              expect(actual).to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
 
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).not_to have_attributes(expected)|,
-            expectation: proc {
-              line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                plain " not to have attributes "
-                alpha %|(name: "a")|
-                plain "."
-              end
-            },
-          )
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).to have_attributes(expected)|,
+              expectation: proc {
+                line do
+                  plain "Expected "
+                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain " to respond to "
+                  alpha %|:foo|
+                  plain " with "
+                  alpha %|0|
+                  plain " arguments."
+                end
+              },
+              diff: proc {
+                plain_line %|  #<SuperDiff::Test::Person {|
+                plain_line %|    name: "a",|
+                # plain_line %|    age: 9,|  # FIXME
+                plain_line %|    age: 9|
+                # alpha_line %|-   foo: "bar",|  # FIXME
+                alpha_line %|-   foo: "bar"|
+                plain_line %|  }>|
+              },
+            )
 
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
         end
       end
     end
 
-    context "when some of the names are not methods on the actual object" do
-      it "produces the correct output" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = { name: "b", foo: "bar" }
-            actual = SuperDiff::Test::Person.new(name: "a", age: 9)
-            expect(actual).to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
+    context "with a large set of attributes" do
+      context "when all of the names are methods on the actual object" do
+        it "produces the correct output when used in the positive" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = {
+                line_1: "123 Main St.",
+                city: "Oakland",
+                state: "CA",
+                zip: "91234"
+              }
+              actual = SuperDiff::Test::ShippingAddress.new(
+                line_1: "456 Ponderosa Ct.",
+                line_2: nil,
+                city: "Hill Valley",
+                state: "CA",
+                zip: "90382"
+              )
+              expect(actual).to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
 
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).to have_attributes(expected)|,
-            expectation: proc {
-              line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|0|
-                plain " arguments."
-              end
-            },
-            diff: proc {
-              plain_line %|  #<SuperDiff::Test::Person {|
-              plain_line %|    name: "a",|
-              # plain_line %|    age: 9,|  # FIXME
-              plain_line %|    age: 9|
-              # alpha_line %|-   foo: "bar",|  # FIXME
-              alpha_line %|-   foo: "bar"|
-              plain_line %|  }>|
-            },
-          )
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).to have_attributes(expected)|,
+              expectation: proc {
+                line do
+                  plain "          Expected "
+                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
+                end
 
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
+                line do
+                  plain "to have attributes "
+                  alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
+                end
+              },
+              diff: proc {
+                plain_line %|  #<SuperDiff::Test::ShippingAddress {|
+                alpha_line %|-   line_1: "123 Main St.",|
+                beta_line  %|+   line_1: "456 Ponderosa Ct.",|
+                plain_line %|    line_2: nil,|
+                alpha_line %|-   city: "Oakland",|
+                beta_line  %|+   city: "Hill Valley",|
+                plain_line %|    state: "CA",|
+                # alpha_line %|-   zip: "91234",|  # FIXME
+                alpha_line %|-   zip: "91234"|
+                beta_line  %|+   zip: "90382"|
+                plain_line %|  }>|
+              },
+            )
+
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
+        end
+
+        it "produces the correct output when used in the negative" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = {
+                line_1: "123 Main St.",
+                city: "Oakland",
+                state: "CA",
+                zip: "91234"
+              }
+              actual = SuperDiff::Test::ShippingAddress.new(
+                line_1: "123 Main St.",
+                line_2: nil,
+                city: "Oakland",
+                state: "CA",
+                zip: "91234"
+              )
+              expect(actual).not_to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
+
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).not_to have_attributes(expected)|,
+              newline_before_expectation: true,
+              expectation: proc {
+                line do
+                  plain "              Expected "
+                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
+                end
+
+                line do
+                  plain "not to have attributes "
+                  alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
+                end
+              },
+            )
+
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
+        end
+      end
+
+      context "when some of the names are not methods on the actual object" do
+        it "produces the correct output" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expected = {
+                line_1: "123 Main St.",
+                city: "Oakland",
+                state: "CA",
+                zip: "91234",
+                foo: "bar",
+                baz: "qux"
+              }
+              actual = SuperDiff::Test::ShippingAddress.new(
+                line_1: "456 Ponderosa Ct.",
+                line_2: nil,
+                city: "Hill Valley",
+                state: "CA",
+                zip: "90382"
+              )
+              expect(actual).to have_attributes(expected)
+            TEST
+            program = make_plain_test_program(
+              snippet,
+              color_enabled: color_enabled,
+            )
+
+            expected_output = build_expected_output(
+              color_enabled: color_enabled,
+              snippet: %|expect(actual).to have_attributes(expected)|,
+              expectation: proc {
+                line do
+                  plain "     Expected "
+                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
+                end
+
+                line do
+                  plain "to respond to "
+                  alpha %|:foo|
+                  plain " and "
+                  alpha %|:baz|
+                  plain " with "
+                  alpha %|0|
+                  plain " arguments"
+                end
+              },
+              diff: proc {
+                plain_line %|  #<SuperDiff::Test::ShippingAddress {|
+                plain_line %|    line_1: "456 Ponderosa Ct.",|
+                plain_line %|    line_2: nil,|
+                plain_line %|    city: "Hill Valley",|
+                plain_line %|    state: "CA",|
+                # plain_line %|    zip: "90382",|  # FIXME
+                plain_line %|    zip: "90382"|
+                # alpha_line %|-   foo: "bar",|  # FIXME
+                alpha_line %|-   foo: "bar"|
+                alpha_line %|-   baz: "qux"|
+                plain_line %|  }>|
+              },
+            )
+
+            expect(program).
+              to produce_output_when_run(expected_output).
+              in_color(color_enabled)
+          end
         end
       end
     end
   end
 
-  context "when given a large set of attributes" do
-    context "when all of the names are methods on the actual object" do
-      it "produces the correct output when used in the positive" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = {
-              line_1: "123 Main St.",
-              city: "Oakland",
-              state: "CA",
-              zip: "91234"
-            }
-            actual = SuperDiff::Test::ShippingAddress.new(
-              line_1: "456 Ponderosa Ct.",
-              line_2: nil,
-              city: "Hill Valley",
-              state: "CA",
-              zip: "90382"
-            )
-            expect(actual).to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
+  context "when the actual value is actually a hash instead of an object" do
+    it "displays the diff as if we were comparing hashes" do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          expected = { name: "Elliot", age: 32 }
+          actual = { name: "Elliot", age: 32 }
+          expect(actual).to have_attributes(expected)
+        TEST
 
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).to have_attributes(expected)|,
-            expectation: proc {
-              line do
-                plain "          Expected "
-                beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
-              end
+        program = make_plain_test_program(snippet, color_enabled: color_enabled)
 
-              line do
-                plain "to have attributes "
-                alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
-              end
-            },
-            diff: proc {
-              plain_line %|  #<SuperDiff::Test::ShippingAddress {|
-              alpha_line %|-   line_1: "123 Main St.",|
-              beta_line  %|+   line_1: "456 Ponderosa Ct.",|
-              plain_line %|    line_2: nil,|
-              alpha_line %|-   city: "Oakland",|
-              beta_line  %|+   city: "Hill Valley",|
-              plain_line %|    state: "CA",|
-              # alpha_line %|-   zip: "91234",|  # FIXME
-              alpha_line %|-   zip: "91234"|
-              beta_line  %|+   zip: "90382"|
-              plain_line %|  }>|
-            },
-          )
+        expected_output = build_expected_output(
+          color_enabled: color_enabled,
+          snippet: %|expect(actual).to have_attributes(expected)|,
+          expectation: proc {
+            line do
+              plain "Expected "
+              beta %|{ name: "Elliot", age: 32 }|
+              plain " to respond to "
+              alpha %|:name|
+              plain " and "
+              alpha %|:age|
+              plain " with "
+              alpha %|0|
+              plain " arguments."
+            end
+          },
+          diff: proc {
+            plain_line %|  {|
+            alpha_line %|-   name: "Elliot",|
+            alpha_line %|-   age: 32|
+            plain_line %|  }|
+          },
+        )
 
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
-        end
-      end
-
-      it "produces the correct output when used in the negative" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = {
-              line_1: "123 Main St.",
-              city: "Oakland",
-              state: "CA",
-              zip: "91234"
-            }
-            actual = SuperDiff::Test::ShippingAddress.new(
-              line_1: "123 Main St.",
-              line_2: nil,
-              city: "Oakland",
-              state: "CA",
-              zip: "91234"
-            )
-            expect(actual).not_to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
-
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).not_to have_attributes(expected)|,
-            newline_before_expectation: true,
-            expectation: proc {
-              line do
-                plain "              Expected "
-                beta %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
-              end
-
-              line do
-                plain "not to have attributes "
-                alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
-              end
-            },
-          )
-
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
-        end
-      end
-    end
-
-    context "when some of the names are not methods on the actual object" do
-      it "produces the correct output" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = {
-              line_1: "123 Main St.",
-              city: "Oakland",
-              state: "CA",
-              zip: "91234",
-              foo: "bar",
-              baz: "qux"
-            }
-            actual = SuperDiff::Test::ShippingAddress.new(
-              line_1: "456 Ponderosa Ct.",
-              line_2: nil,
-              city: "Hill Valley",
-              state: "CA",
-              zip: "90382"
-            )
-            expect(actual).to have_attributes(expected)
-          TEST
-          program = make_plain_test_program(
-            snippet,
-            color_enabled: color_enabled,
-          )
-
-          expected_output = build_expected_output(
-            color_enabled: color_enabled,
-            snippet: %|expect(actual).to have_attributes(expected)|,
-            expectation: proc {
-              line do
-                plain "     Expected "
-                beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
-              end
-
-              line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain " and "
-                alpha %|:baz|
-                plain " with "
-                alpha %|0|
-                plain " arguments"
-              end
-            },
-            diff: proc {
-              plain_line %|  #<SuperDiff::Test::ShippingAddress {|
-              plain_line %|    line_1: "456 Ponderosa Ct.",|
-              plain_line %|    line_2: nil,|
-              plain_line %|    city: "Hill Valley",|
-              plain_line %|    state: "CA",|
-              # plain_line %|    zip: "90382",|  # FIXME
-              plain_line %|    zip: "90382"|
-              # alpha_line %|-   foo: "bar",|  # FIXME
-              alpha_line %|-   foo: "bar"|
-              alpha_line %|-   baz: "qux"|
-              plain_line %|  }>|
-            },
-          )
-
-          expect(program).
-            to produce_output_when_run(expected_output).
-            in_color(color_enabled)
-        end
+        expect(program).
+          to produce_output_when_run(expected_output).
+          in_color(color_enabled)
       end
     end
   end

--- a/spec/support/integration/matchers/produce_output_when_run_matcher.rb
+++ b/spec/support/integration/matchers/produce_output_when_run_matcher.rb
@@ -48,13 +48,17 @@ module SuperDiff
             "Actual output:\n\n" +
             CommandRunner::OutputHelpers.bookended(actual_output)
 
-          ::RSpec::Matchers::ExpectedsForMultipleDiffs.
-            from(expected_output).
-            message_with_diff(
-              message,
-              ::RSpec::Expectations.differ,
-              actual_output,
-            )
+          if ["1", "true"].include?(ENV["SHOW_DIFF"])
+            ::RSpec::Matchers::ExpectedsForMultipleDiffs.
+              from(expected_output).
+              message_with_diff(
+                message,
+                ::RSpec::Expectations.differ,
+                actual_output,
+              )
+          else
+            message
+          end
         end
       end
 


### PR DESCRIPTION
The `have_attributes` matcher is not "supposed" to be used against a
hash, but considering Hash is an object, it is still a perfectly valid
use case. Still, typically, such a test will probably fail, and so the
failure should show an appropriate diff. Currently, the representation
of the subject in said diff is very low-level, as the DefaultObject diff
formatter is being utilized (as Differs::ObjectHavingAttributes inherits
from Differs::DefaultObject, and Differs::DefaultObject uses
DiffFormatters::DefaultObject). Instead we should be using whatever
DiffFormatter is appropriate for the type of subject: hash, array, etc.
Changing this is non-trivial, but it is this with which the majority of
this commit is concerned.