### PR TITLE
Retain original ordering of keys when diffing hashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,8 @@ Metrics/BlockLength:
     - shared_context
     - shared_examples
     - shared_examples_for
+Metrics/BlockNesting:
+  Enabled: false
 Metrics/ClassLength:
   Enabled: false
 Metrics/CyclomaticComplexity:
@@ -115,9 +117,13 @@ Style/NegatedIf:
   Enabled: false
 Style/NegatedWhile:
   Enabled: false
+Style/Next:
+  Enabled: false
 Style/NumericPredicate:
   Enabled: false
 Style/OneLineConditional:
+  Enabled: false
+Style/ParallelAssignment:
   Enabled: false
 Style/PercentLiteralDelimiters:
   Enabled: false

--- a/lib/super_diff/operational_sequencers/array.rb
+++ b/lib/super_diff/operational_sequencers/array.rb
@@ -32,36 +32,15 @@ module SuperDiff
         public :operations
 
         def match(event)
-          operations << ::SuperDiff::Operations::UnaryOperation.new(
-            name: :noop,
-            collection: actual,
-            key: event.new_position,
-            value: event.new_element,
-            index: event.new_position,
-            index_in_collection: actual.index(event.new_element),
-          )
+          add_noop_operation(event)
         end
 
         def discard_a(event)
-          operations << ::SuperDiff::Operations::UnaryOperation.new(
-            name: :delete,
-            collection: expected,
-            key: event.old_position,
-            value: event.old_element,
-            index: event.old_position,
-            index_in_collection: expected.index(event.old_element),
-          )
+          add_delete_operation(event)
         end
 
         def discard_b(event)
-          operations << ::SuperDiff::Operations::UnaryOperation.new(
-            name: :insert,
-            collection: actual,
-            key: event.new_position,
-            value: event.new_element,
-            index: event.new_position,
-            index_in_collection: actual.index(event.new_element),
-          )
+          add_insert_operation(event)
         end
 
         def change(event)
@@ -76,21 +55,6 @@ module SuperDiff
         end
 
         private
-
-        def add_change_operation(event, child_operations)
-          operations << ::SuperDiff::Operations::BinaryOperation.new(
-            name: :change,
-            left_collection: expected,
-            right_collection: actual,
-            left_key: event.old_position,
-            right_key: event.new_position,
-            left_value: event.old_element,
-            right_value: event.new_element,
-            left_index: event.old_position,
-            right_index: event.new_position,
-            child_operations: child_operations,
-          )
-        end
 
         def add_delete_operation(event)
           operations << Operations::UnaryOperation.new(
@@ -113,6 +77,33 @@ module SuperDiff
             index_in_collection: actual.index(event.new_element),
           )
         end
+
+        def add_noop_operation(event)
+          operations << ::SuperDiff::Operations::UnaryOperation.new(
+            name: :noop,
+            collection: actual,
+            key: event.new_position,
+            value: event.new_element,
+            index: event.new_position,
+            index_in_collection: actual.index(event.new_element),
+          )
+        end
+
+        def add_change_operation(event, child_operations)
+          operations << ::SuperDiff::Operations::BinaryOperation.new(
+            name: :change,
+            left_collection: expected,
+            right_collection: actual,
+            left_key: event.old_position,
+            right_key: event.new_position,
+            left_value: event.old_element,
+            right_value: event.new_element,
+            left_index: event.old_position,
+            right_index: event.new_position,
+            child_operations: child_operations,
+          )
+        end
+
       end
     end
   end

--- a/lib/super_diff/operational_sequencers/hash.rb
+++ b/lib/super_diff/operational_sequencers/hash.rb
@@ -8,12 +8,7 @@ module SuperDiff
       protected
 
       def unary_operations
-        all_keys.reduce([]) do |operations, key|
-          possibly_add_noop_to(operations, key)
-          possibly_add_delete_to(operations, key)
-          possibly_add_insert_to(operations, key)
-          operations
-        end
+        unary_operations_using_variant_of_patience_algorithm
       end
 
       def build_operation_sequence
@@ -22,63 +17,210 @@ module SuperDiff
 
       private
 
-      def all_keys
-        actual.keys | expected.keys
-      end
+      def unary_operations_using_variant_of_patience_algorithm
+        operations = []
+        aks, eks = actual.keys, expected.keys
+        previous_ei, ei = nil, 0
+        ai = 0
 
-      def possibly_add_noop_to(operations, key)
-        if should_add_noop_operation?(key)
-          operations << Operations::UnaryOperation.new(
-            name: :noop,
-            collection: actual,
-            key: key,
-            index: all_keys.index(key),
-            index_in_collection: actual.keys.index(key),
-            value: actual[key],
-          )
+        # When diffing a hash, we're more interested in the 'actual' version
+        # than the 'expected' version, because that's the ultimate truth.
+        # Therefore, the diff is presented from the perspective of the 'actual'
+        # hash, and we start off by looping over it.
+        while ai < aks.size
+          ak = aks[ai]
+          av, ev = actual[ak], expected[ak]
+          # While we iterate over 'actual' in order, we jump all over
+          # 'expected', trying to match up its keys with the keys in 'actual' as
+          # much as possible.
+          ei = eks.index(ak)
+
+          if should_add_noop_operation?(ak)
+            # (If we're here, it probably means that the key we're pointing to
+            # in the 'actual' and 'expected' hashes have the same value.)
+
+            if ei && previous_ei && (ei - previous_ei) > 1
+              # If we've jumped from one operation in the 'expected' hash to
+              # another operation later in 'expected' (due to the fact that the
+              # 'expected' hash is in a different order than 'actual'), collect
+              # any delete operations in between and add them to our operations
+              # array as deletes before adding the noop. If we don't do this
+              # now, then those deletes will disappear. (Again, we are mainly
+              # iterating over 'actual', so this is the only way to catch all of
+              # the keys in 'expected'.)
+              (previous_ei + 1).upto(ei - 1) do |ei2|
+                ek = eks[ei2]
+                ev2, av2 = expected[ek], actual[ek]
+
+                if (
+                  (!actual.include?(ek) || ev != av2) &&
+                  operations.none? { |operation|
+                    [:delete, :noop].include?(operation.name) &&
+                      operation.key == ek
+                  }
+                )
+                  operations << Operations::UnaryOperation.new(
+                    name: :delete,
+                    collection: expected,
+                    key: ek,
+                    value: ev2,
+                    index: ei2,
+                    index_in_collection: ei2,
+                  )
+                end
+              end
+            end
+
+            operations << Operations::UnaryOperation.new(
+              name: :noop,
+              collection: actual,
+              key: ak,
+              value: av,
+              index: ai,
+              index_in_collection: ai,
+            )
+          else
+            # (If we're here, it probably means that the key in 'actual' isn't
+            # present in 'expected' or the values don't match.)
+
+            if (
+              (operations.empty? || operations.last.name == :noop) &&
+              (ai == 0 || eks.include?(aks[ai - 1]))
+            )
+              # If we go from a match in the last iteration to a missing or
+              # extra key in this one, or we're at the first key in 'actual' and
+              # it's missing or extra, look for deletes in the 'expected' hash
+              # and add them to our list of operations before we add the
+              # inserts. In most cases we will accomplish this by backtracking a
+              # bit to the key in 'expected' that matched the key in 'actual' we
+              # processed in the previous iteration (or just the first key in
+              # 'expected' if this is the first key in 'actual'), and then
+              # iterating from there through 'expected' until we reach the end
+              # or we hit some other condition (see below).
+
+              start_index =
+                if ai > 0
+                  eks.index(aks[ai - 1]) + 1
+                else
+                  0
+                end
+
+              start_index.upto(eks.size - 1) do |ei2|
+                ek = eks[ei2]
+                ev, av2 = expected[ek], actual[ek]
+                ai2 = aks.index(ek)
+
+                if actual.include?(ek) && ev == av2
+                  # If the key in 'expected' we've landed on happens to be a
+                  # match in 'actual', then stop, because it's going to be
+                  # handled in some future iteration of the 'actual' loop.
+                  break
+                elsif (
+                  aks[ai + 1 .. -1].any? { |k|
+                    expected.include?(k) && expected[k] != actual[k]
+                  }
+                )
+                  # While we backtracked a bit to iterate over 'expected', we
+                  # now have to look ahead. If we will end up encountering a
+                  # insert that matches this delete later, stop and go back to
+                  # iterating over 'actual'. This is because the delete we would
+                  # have added now will be added later when we encounter the
+                  # associated insert, so we don't want to add it twice.
+                  break
+                else
+                  operations << Operations::UnaryOperation.new(
+                    name: :delete,
+                    collection: expected,
+                    key: ek,
+                    value: ev,
+                    index: ei2,
+                    index_in_collection: ei2,
+                  )
+                end
+
+                if ek == ak && ev != av
+                  # If we're pointing to the same key in 'expected' as in
+                  # 'actual', but with different values, go ahead and add an
+                  # insert now to accompany the delete added above. That way
+                  # they appear together, which will be easier to read.
+                  operations << Operations::UnaryOperation.new(
+                    name: :insert,
+                    collection: actual,
+                    key: ak,
+                    value: av,
+                    index: ai,
+                    index_in_collection: ai,
+                  )
+                end
+              end
+            end
+
+            if (
+              expected.include?(ak) &&
+              ev != av &&
+              operations.none? { |op| op.name == :delete && op.key == ak }
+            )
+              # If we're here, it means that we didn't encounter any delete
+              # operations above for whatever reason and so we need to add a
+              # delete to represent the fact that the value for this key has
+              # changed.
+              operations << Operations::UnaryOperation.new(
+                name: :delete,
+                collection: expected,
+                key: ak,
+                value: expected[ak],
+                index: ei,
+                index_in_collection: ei,
+              )
+            end
+
+            if operations.none? { |op| op.name == :insert && op.key == ak }
+              # If we're here, it means that we didn't encounter any insert
+              # operations above. Since we already handled delete, the only
+              # alternative is that this key must not exist in 'expected', so
+              # we need to add an insert.
+              operations << Operations::UnaryOperation.new(
+                name: :insert,
+                collection: actual,
+                key: ak,
+                value: av,
+                index: ai,
+                index_in_collection: ai,
+              )
+            end
+          end
+
+          ai += 1
+          previous_ei = ei
         end
-      end
 
-      def should_add_noop_operation?(key)
-        expected.include?(key) &&
-          actual.include?(key) &&
-          expected[key] == actual[key]
-      end
+        # The last thing to do is this: if there are keys in 'expected' that
+        # aren't in 'actual', and they aren't associated with any inserts to
+        # where they would have been added above, tack those deletes onto the
+        # end of our operations array.
+        (eks - aks - operations.map(&:key)).each do |ek|
+          ei = eks.index(ek)
+          ev = expected[ek]
 
-      def possibly_add_delete_to(operations, key)
-        if should_add_delete_operation?(key)
           operations << Operations::UnaryOperation.new(
             name: :delete,
             collection: expected,
-            key: key,
-            index: all_keys.index(key),
-            index_in_collection: expected.keys.index(key),
-            value: expected[key],
+            key: ek,
+            value: ev,
+            index: ei,
+            index_in_collection: ei,
           )
         end
+
+        operations
       end
 
-      def should_add_delete_operation?(key)
-        expected.include?(key) &&
-          (!actual.include?(key) || expected[key] != actual[key])
+      def should_add_noop_operation?(key)
+        expected.include?(key) && expected[key] == actual[key]
       end
 
-      def possibly_add_insert_to(operations, key)
-        if should_add_insert_operation?(key)
-          operations << Operations::UnaryOperation.new(
-            name: :insert,
-            collection: actual,
-            key: key,
-            index: all_keys.index(key),
-            index_in_collection: actual.keys.index(key),
-            value: actual[key],
-          )
-        end
-      end
-
-      def should_add_insert_operation?(key)
-        !expected.include?(key) ||
-          (actual.include?(key) && expected[key] != actual[key])
+      def all_keys
+        actual.keys | expected.keys
       end
     end
   end

--- a/lib/super_diff/operations/unary_operation.rb
+++ b/lib/super_diff/operations/unary_operation.rb
@@ -6,6 +6,7 @@ module SuperDiff
         :collection,
         :key,
         :value,
+        # TODO: Is this even used??
         :index,
         :index_in_collection,
       )
@@ -15,6 +16,7 @@ module SuperDiff
         collection:,
         key:,
         value:,
+        # TODO: Is this even used??
         index:,
         index_in_collection: index
       )
@@ -22,6 +24,7 @@ module SuperDiff
         @collection = collection
         @key = key
         @value = value
+        # TODO: Is this even used??
         @index = index
         @index_in_collection = index_in_collection
       end

--- a/lib/super_diff/rspec/operational_sequencers/hash_including.rb
+++ b/lib/super_diff/rspec/operational_sequencers/hash_including.rb
@@ -8,9 +8,7 @@ module SuperDiff
         end
 
         def initialize(expected:, **rest)
-          super
-
-          @expected = expected.expecteds.first
+          super(expected: expected.expecteds.first, **rest)
         end
 
         private
@@ -20,12 +18,6 @@ module SuperDiff
             actual.include?(key) &&
             expected[key] == actual[key]
           )
-        end
-
-        def should_add_insert_operation?(key)
-          expected.include?(key) &&
-            actual.include?(key) &&
-            expected[key] != actual[key]
         end
       end
     end

--- a/spec/integration/rspec/include_matcher_spec.rb
+++ b/spec/integration/rspec/include_matcher_spec.rb
@@ -214,9 +214,9 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
               alpha_line %|-   city: "Hill Valley",|
               beta_line  %|+   city: "Burbank",|
               # FIXME
-              # plain_line %|    zip: "90210",|
-              plain_line %|    zip: "90210"|
+              # alpha_line %|-   state: "CA",|
               alpha_line %|-   state: "CA"|
+              plain_line %|    zip: "90210"|
               plain_line %|  }|
             },
           )

--- a/spec/unit/equality_matcher_spec.rb
+++ b/spec/unit/equality_matcher_spec.rb
@@ -1056,6 +1056,162 @@ RSpec.describe SuperDiff::EqualityMatcher do
       end
     end
 
+    context "given two equal-size, one-dimensional hashes where there is a mixture of missing and extra keys in relatively the same order" do
+      context "and the actual value is in relatively the same order as the expected" do
+        it "preserves the order of the keys as they are defined" do
+          actual_output = described_class.call(
+            expected: {
+              listed_count: 37_009,
+              created_at: "Tue Jan 13 19:28:24 +0000 2009",
+              favourites_count: 38,
+              geo_enabled: false,
+              verified: true,
+              statuses_count: 273_860,
+              media_count: 51_044,
+              contributors_enabled: false,
+              profile_background_color: "FFF1E0",
+              profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",
+              profile_background_tile: false,
+              profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",
+              profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",
+              profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592",
+            },
+            actual: {
+              listed_count: 37_009,
+              created_at: "Tue Jan 13 19:28:24 +0000 2009",
+              favourites_count: 38,
+              utc_offset: nil,
+              time_zone: nil,
+              statuses_count: 273_860,
+              media_count: 51_044,
+              contributors_enabled: false,
+              is_translator: false,
+              is_translation_enabled: false,
+              profile_background_color: "FFF1E0",
+              profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",
+              profile_background_tile: false,
+              profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592",
+            }
+          )
+
+          expected_output = <<~STR.strip
+            Differing hashes.
+
+            #{
+              colored do
+                alpha_line %(Expected: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, statuses_count: 273860, media_count: 51044, contributors_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                beta_line  %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, time_zone: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+              end
+            }
+
+            Diff:
+
+            #{
+              colored do
+                plain_line %(  {)
+                plain_line %(    listed_count: 37009,)
+                plain_line %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
+                plain_line %(    favourites_count: 38,)
+                alpha_line %(-   geo_enabled: false,)
+                alpha_line %(-   verified: true,)
+                beta_line  %(+   utc_offset: nil,)
+                beta_line  %(+   time_zone: nil,)
+                plain_line %(    statuses_count: 273860,)
+                plain_line %(    media_count: 51044,)
+                plain_line %(    contributors_enabled: false,)
+                beta_line  %(+   is_translator: false,)
+                beta_line  %(+   is_translation_enabled: false,)
+                plain_line %(    profile_background_color: "FFF1E0",)
+                plain_line %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
+                plain_line %(    profile_background_tile: false,)
+                alpha_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                alpha_line %(-   profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                plain_line %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
+                plain_line %(  })
+              end
+            }
+          STR
+
+          expect(actual_output).to eq(expected_output)
+        end
+      end
+
+      context "and the actual value is in a different order than the expected" do
+        it "preserves the order of the keys as they are defined" do
+          actual_output = described_class.call(
+            expected: {
+              created_at: "Tue Jan 13 19:28:24 +0000 2009",
+              favourites_count: 38,
+              geo_enabled: false,
+              verified: true,
+              media_count: 51_044,
+              statuses_count: 273_860,
+              contributors_enabled: false,
+              profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",
+              profile_background_color: "FFF1E0",
+              profile_background_tile: false,
+              profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",
+              listed_count: 37_009,
+              profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592",
+            },
+            actual: {
+              listed_count: 37_009,
+              created_at: "Tue Jan 13 19:28:24 +0000 2009",
+              favourites_count: 38,
+              utc_offset: nil,
+              statuses_count: 273_860,
+              media_count: 51_044,
+              contributors_enabled: false,
+              is_translator: false,
+              is_translation_enabled: false,
+              profile_background_color: "FFF1E0",
+              profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",
+              profile_background_tile: false,
+              profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592",
+            }
+          )
+
+          expected_output = <<~STR.strip
+            Differing hashes.
+
+            #{
+              colored do
+                alpha_line %(Expected: { created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, media_count: 51044, statuses_count: 273860, contributors_enabled: false, profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_color: "FFF1E0", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", listed_count: 37009, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                beta_line  %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+              end
+            }
+
+            Diff:
+
+            #{
+              colored do
+                plain_line %(  {)
+                plain_line %(    listed_count: 37009,)
+                plain_line %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
+                plain_line %(    favourites_count: 38,)
+                alpha_line %(-   geo_enabled: false,)
+                alpha_line %(-   verified: true,)
+                beta_line  %(+   utc_offset: nil,)
+                plain_line %(    statuses_count: 273860,)
+                plain_line %(    media_count: 51044,)
+                plain_line %(    contributors_enabled: false,)
+                beta_line  %(+   is_translator: false,)
+                beta_line  %(+   is_translation_enabled: false,)
+                plain_line %(    profile_background_color: "FFF1E0",)
+                plain_line %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
+                plain_line %(    profile_background_tile: false,)
+                alpha_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                plain_line %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
+                plain_line %(  })
+              end
+            }
+          STR
+
+          expect(actual_output).to eq(expected_output)
+        end
+      end
+    end
+
     context "given two hashes containing arrays with differing values" do
       it "returns a message along with the diff" do
         actual_output = described_class.call(


### PR DESCRIPTION
If you have two hashes and there are missing or extra keys on either
side, remember what the order of those keys were and use that same
ordering when producing the diff instead of sticking those keys at the
end of the diff.