### PR TITLE
Add attr_extras as runtime dependence

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "appraisal"
-gem "attr_extras", github: "barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/no_rails.gemfile
+++ b/gemfiles/no_rails.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "attr_extras", git: "https://github.com/barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/no_rails.gemfile.lock
+++ b/gemfiles/no_rails.gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/barsoom/attr_extras
-  revision: 7bdf20ac699967610ad8e6c910eff27ead8d135c
-  specs:
-    attr_extras (6.2.4)
-
 PATH
   remote: ..
   specs:
     super_diff (0.5.0)
+      attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
 
@@ -19,6 +14,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
+    attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -68,7 +64,6 @@ PLATFORMS
 
 DEPENDENCIES
   appraisal
-  attr_extras!
   childprocess
   pry-byebug
   pry-nav

--- a/gemfiles/rails_5_0.gemfile
+++ b/gemfiles/rails_5_0.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "attr_extras", git: "https://github.com/barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/rails_5_0.gemfile.lock
+++ b/gemfiles/rails_5_0.gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/barsoom/attr_extras
-  revision: 7bdf20ac699967610ad8e6c910eff27ead8d135c
-  specs:
-    attr_extras (6.2.4)
-
 PATH
   remote: ..
   specs:
     super_diff (0.5.0)
+      attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
 
@@ -31,6 +26,7 @@ GEM
       thor (>= 0.14.0)
     arel (7.1.4)
     ast (2.4.0)
+    attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -90,7 +86,6 @@ DEPENDENCIES
   activerecord (~> 5.0.0)
   activerecord-jdbcsqlite3-adapter
   appraisal
-  attr_extras!
   childprocess
   jdbc-sqlite3
   pry-byebug

--- a/gemfiles/rails_5_1.gemfile
+++ b/gemfiles/rails_5_1.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "attr_extras", git: "https://github.com/barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/rails_5_1.gemfile.lock
+++ b/gemfiles/rails_5_1.gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/barsoom/attr_extras
-  revision: 7bdf20ac699967610ad8e6c910eff27ead8d135c
-  specs:
-    attr_extras (6.2.4)
-
 PATH
   remote: ..
   specs:
     super_diff (0.5.0)
+      attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
 
@@ -31,6 +26,7 @@ GEM
       thor (>= 0.14.0)
     arel (8.0.0)
     ast (2.4.0)
+    attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -90,7 +86,6 @@ DEPENDENCIES
   activerecord (~> 5.1.0)
   activerecord-jdbcsqlite3-adapter
   appraisal
-  attr_extras!
   childprocess
   jdbc-sqlite3
   pry-byebug

--- a/gemfiles/rails_5_2.gemfile
+++ b/gemfiles/rails_5_2.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "attr_extras", git: "https://github.com/barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/rails_5_2.gemfile.lock
+++ b/gemfiles/rails_5_2.gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/barsoom/attr_extras
-  revision: 7bdf20ac699967610ad8e6c910eff27ead8d135c
-  specs:
-    attr_extras (6.2.4)
-
 PATH
   remote: ..
   specs:
     super_diff (0.5.0)
+      attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
 
@@ -31,6 +26,7 @@ GEM
       thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.0)
+    attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -90,7 +86,6 @@ DEPENDENCIES
   activerecord (~> 5.2.0)
   activerecord-jdbcsqlite3-adapter
   appraisal
-  attr_extras!
   childprocess
   jdbc-sqlite3
   pry-byebug

--- a/gemfiles/rails_6_0.gemfile
+++ b/gemfiles/rails_6_0.gemfile
@@ -3,7 +3,6 @@
 source "https://rubygems.org"
 
 gem "appraisal"
-gem "attr_extras", git: "https://github.com/barsoom/attr_extras"
 gem "childprocess"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby

--- a/gemfiles/rails_6_0.gemfile.lock
+++ b/gemfiles/rails_6_0.gemfile.lock
@@ -1,13 +1,8 @@
-GIT
-  remote: https://github.com/barsoom/attr_extras
-  revision: 7bdf20ac699967610ad8e6c910eff27ead8d135c
-  specs:
-    attr_extras (6.2.4)
-
 PATH
   remote: ..
   specs:
     super_diff (0.5.0)
+      attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
 
@@ -30,6 +25,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.0)
+    attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (3.0.0)
     coderay (1.1.2)
@@ -90,7 +86,6 @@ DEPENDENCIES
   activerecord (~> 6.0)
   activerecord-jdbcsqlite3-adapter
   appraisal
-  attr_extras!
   childprocess
   jdbc-sqlite3
   pry-byebug

--- a/super_diff.gemspec
+++ b/super_diff.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir["spec/**/*"]
   s.executables   = Dir["exe/**/*"].map { |f| File.basename(f) }
 
+  s.add_dependency "attr_extras", '>= 6.2.4'
   s.add_dependency "diff-lcs"
   s.add_dependency "patience_diff"
 end


### PR DESCRIPTION
version 0.5.0 crashes now because we are using `attr_extras` aa dependency https://github.com/mcmire/super_diff/blob/master/lib/super_diff.rb#L1 but not include this lib in gemspec. 