### PR TITLE
Add missing stdlib requires.

### DIFF
--- a/lib/super_diff/operation_trees/base.rb
+++ b/lib/super_diff/operation_trees/base.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module SuperDiff
   module OperationTrees
     class Base < SimpleDelegator

--- a/lib/super_diff/recursion_guard.rb
+++ b/lib/super_diff/recursion_guard.rb
@@ -1,3 +1,5 @@
+require 'set'
+
 module SuperDiff
   module RecursionGuard
     RECURSION_GUARD_KEY = "super_diff_recursion_guard_key".freeze


### PR DESCRIPTION
When using super_diff in an RSpec suite that does not load `set`
or `delegate` from the standard library, I was getting errors:

* `NameError: uninitialized constant SuperDiff::RecursionGuard::Set`
* `NameError: uninitialized constant SuperDiff::OperationTrees::SimpleDelegator`

The requires added here fix these errors.

super_diff should load all parts of the stdlib it uses rather than
assuming other things load them.