### PR TITLE
Add actual but not expected items in the contains exactly matcher

### DIFF
--- a/lib/super_diff/rspec/operation_tree_builders/collection_containing_exactly.rb
+++ b/lib/super_diff/rspec/operation_tree_builders/collection_containing_exactly.rb
@@ -17,8 +17,14 @@ module SuperDiff
         def unary_operations
           operations = []
 
-          (0...actual.length).each do |index|
+          (0...actual.length).reject do |index|
+            indexes_in_actual_but_not_in_expected.include?(index)
+          end.each do |index|
             add_noop_to(operations, index)
+          end
+
+          indexes_in_actual_but_not_in_expected.each do |index|
+            add_insert_to(operations, index)
           end
 
           indexes_in_expected_but_not_in_actual.each do |index|
@@ -82,6 +88,11 @@ module SuperDiff
           indexes_in_expected_but_not_in_actual.map do |index|
             expected.expected[index]
           end
+        end
+
+        def indexes_in_actual_but_not_in_expected
+          @indexes_in_actual_but_not_in_expected ||=
+            pairings_maximizer_best_solution.unmatched_actual_indexes
         end
 
         def indexes_in_expected_but_not_in_actual

--- a/spec/integration/rspec/contain_exactly_matcher_spec.rb
+++ b/spec/integration/rspec/contain_exactly_matcher_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
           diff: proc {
             plain_line %|  [|
             plain_line %|    "Marty",|
-            plain_line %|    "Jennifer",|
-            plain_line %|    "Doc",|
+            beta_line  %|+   "Jennifer",|
+            beta_line  %|+   "Doc",|
             alpha_line %|-   "Einie"|
             plain_line %|  ]|
           },
@@ -129,8 +129,8 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               plain_line %|  [|
               plain_line %|    "Marty McFly",|
               plain_line %|    "Doc Brown",|
-              plain_line %|    "Einie",|
               plain_line %|    "Lorraine McFly",|
+              beta_line  %|+   "Einie",|
               alpha_line %|-   "Biff Tannen",|
               alpha_line %|-   "George McFly"|
               plain_line %|  ]|
@@ -239,8 +239,8 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               plain_line %|  [|
               plain_line %|    "Marty McFly",|
               plain_line %|    "Doc Brown",|
-              plain_line %|    "Einie",|
-              plain_line %|    "Lorraine McFly",|
+              beta_line  %|+   "Einie",|
+              beta_line  %|+   "Lorraine McFly",|
               alpha_line %|-   "Biff Tannen",|
               alpha_line %|-   /Georg McFly/,|
               alpha_line %|-   /Lorrain McFly/|
@@ -348,9 +348,9 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               plain_line %|      foo: "bar"|
               plain_line %|    },|
               plain_line %|    #<Double (anonymous)>,|
-              plain_line %|    {|
-              plain_line %|      blargh: "riddle"|
-              plain_line %|    },|
+              beta_line  %|+   {|
+              beta_line  %|+     blargh: "riddle"|
+              beta_line  %|+   },|
               alpha_line %|-   #<a collection containing exactly (|
               alpha_line %|-     "zing"|
               alpha_line %|-   )>|

--- a/spec/integration/rspec/match_array_matcher_spec.rb
+++ b/spec/integration/rspec/match_array_matcher_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
           diff: proc {
             plain_line %|  [|
             plain_line %|    "Marty",|
-            plain_line %|    "Jennifer",|
-            plain_line %|    "Doc",|
+            beta_line  %|+   "Jennifer",|
+            beta_line  %|+   "Doc",|
             alpha_line %|-   "Einie"|
             plain_line %|  ]|
           },
@@ -129,8 +129,8 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               plain_line %|  [|
               plain_line %|    "Marty McFly",|
               plain_line %|    "Doc Brown",|
-              plain_line %|    "Einie",|
               plain_line %|    "Lorraine McFly",|
+              beta_line  %|+   "Einie",|
               alpha_line %|-   "Biff Tannen",|
               alpha_line %|-   "George McFly"|
               plain_line %|  ]|
@@ -239,8 +239,8 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               plain_line %|  [|
               plain_line %|    "Marty McFly",|
               plain_line %|    "Doc Brown",|
-              plain_line %|    "Einie",|
-              plain_line %|    "Lorraine McFly",|
+              beta_line  %|+   "Einie",|
+              beta_line  %|+   "Lorraine McFly",|
               alpha_line %|-   "Biff Tannen",|
               alpha_line %|-   /Georg McFly/,|
               alpha_line %|-   /Lorrain McFly/|
@@ -352,9 +352,9 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               plain_line %|      foo: "bar"|
               plain_line %|    },|
               plain_line %|    #<Double (anonymous)>,|
-              plain_line %|    {|
-              plain_line %|      blargh: "riddle"|
-              plain_line %|    },|
+              beta_line  %|+   {|
+              beta_line  %|+     blargh: "riddle"|
+              beta_line  %|+   },|
               alpha_line %|-   #<a collection containing exactly (|
               alpha_line %|-     "zing"|
               alpha_line %|-   )>|
@@ -397,9 +397,9 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
           },
           diff: proc {
             plain_line %|  [|
-            plain_line %|    "Marty",|
-            plain_line %|    "Jennifer",|
-            plain_line %|    "Doc",|
+            beta_line  %|+   "Marty",|
+            beta_line  %|+   "Jennifer",|
+            beta_line  %|+   "Doc",|
             alpha_line %|-   "Einie"|
             plain_line %|  ]|
           },

--- a/spec/integration/rspec/match_matcher_spec.rb
+++ b/spec/integration/rspec/match_matcher_spec.rb
@@ -981,7 +981,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             },
             diff: proc {
               plain_line %|  [|
-              plain_line %|    "b",|
+              beta_line  %|+   "b",|
               alpha_line %|-   "a"|
               plain_line %|  ]|
             },
@@ -1056,10 +1056,10 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             diff: proc {
               plain_line %|  [|
               plain_line %|    "milk",|
-              plain_line %|    "toast",|
-              plain_line %|    "eggs",|
-              plain_line %|    "cheese",|
-              plain_line %|    "English muffins",|
+              beta_line  %|+   "toast",|
+              beta_line  %|+   "eggs",|
+              beta_line  %|+   "cheese",|
+              beta_line  %|+   "English muffins",|
               alpha_line %|-   "bread"|
               plain_line %|  ]|
             },
@@ -1147,8 +1147,8 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               plain_line %|    name: "shopping list",|
               plain_line %|    contents: [|
               plain_line %|      "milk",|
-              plain_line %|      "toast",|
-              plain_line %|      "eggs",|
+              beta_line  %|+     "toast",|
+              beta_line  %|+     "eggs",|
               alpha_line %|-     "bread"|
               plain_line %|    ]|
               plain_line %|  }|


### PR DESCRIPTION
Contain exactly would previously not show any diff if there were things in the actual list that weren't in the expected list, but this is still a failure case.