### PR TITLE
Add a license declaration to the gemspec

### DIFF
--- a/super_diff.gemspec
+++ b/super_diff.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.email       = ["elliot.winkler@gmail.com"]
   s.homepage    = "https://github.com/mcmire/super_diff"
   s.summary     = "A better way to view differences between complex data structures in RSpec."
+  s.license     = "MIT"
   s.description = <<~DESC
     SuperDiff is a gem that hooks into RSpec to intelligently display the
     differences between two data structures of any type.


### PR DESCRIPTION
There is a field in the gemspec specification that allows a gem to declare its license programmatically. See the details [here](https://guides.rubygems.org/specification-reference/#licenseo). The specification says it "should" be present.

The gem license_finder is one of the apps that requires it to be there to tell the license of a project. See [here](https://github.com/pivotal/LicenseFinder#a-plea-to-package-authors-and-maintainers) for their description of how/why/where they expect that line.

Closes: https://github.com/mcmire/super_diff/issues/109