### PR TITLE
Add an explicit require for "active_record"

### DIFF
--- a/lib/super_diff/active_record/monkey_patches.rb
+++ b/lib/super_diff/active_record/monkey_patches.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 # rubocop:disable Style/BracesAroundHashParameters, Style/ClassAndModuleChildren
 class ActiveRecord::Base
   def attributes_for_super_diff

--- a/spec/combustion/Gemfile
+++ b/spec/combustion/Gemfile
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "rails"
+
+group :test do
+  gem "combustion"
+  gem "rspec-rails"
+
+  # Use this one to see the problem
+  gem "super_diff", "0.5.3"
+
+  # Use this one to see it fixed
+  # gem "super_diff", path: "../../"
+end

--- a/spec/combustion/README.txt
+++ b/spec/combustion/README.txt
@@ -1,4 +1,4 @@
-You can demonstrate the problem by runnin the following in this directory:
+You can demonstrate the problem by running the following in this directory:
 
 ```ruby
 bundle exec ruby combustion_example.rb

--- a/spec/combustion/README.txt
+++ b/spec/combustion/README.txt
@@ -1,0 +1,5 @@
+You can demonstrate the problem by runnin the following in this directory:
+
+```ruby
+bundle exec ruby combustion_example.rb
+```

--- a/spec/combustion/combustion_example.rb
+++ b/spec/combustion/combustion_example.rb
@@ -1,0 +1,16 @@
+# Set up Combustion as close to https://github.com/pat/combustion#usage as possible
+
+require 'bundler'
+
+Bundler.require :default, :development
+
+require "combustion"
+
+Combustion.initialize! :action_controller
+
+require "rspec/rails"
+require "super_diff"
+require "super_diff/rails"
+
+# It doesn't actually matter that there are no rspec or combustion based tests. By now the problem
+# will have already happened or not.


### PR DESCRIPTION
It is possible for `super_diff` to break with `rails` if required in a certain order. 

You can demonstrate by running this file:

```ruby
require "bundler/inline"

gemfile do
  source "https://rubygems.org"
  gem "rails"
  gem "super_diff"
end

require "rails"
require "super_diff"
require "super_diff/rails"
```

You get:

```
super_diff/lib/super_diff/rails.rb:1:in `<top (required)>'
super_diff/lib/super_diff/active_record.rb:39:in `<top (required)>'
super_diff/lib/super_diff/active_record/monkey_patches.rb:4:
    in `<top (required)>': uninitialized constant ActiveRecord (NameError)
```

This PR covers for that case.