### PR TITLE
Simplify color configuration

### DIFF
--- a/lib/super_diff/colorized_document_extensions.rb
+++ b/lib/super_diff/colorized_document_extensions.rb
@@ -6,12 +6,12 @@ module SuperDiff
       end
     end
 
-    def alpha(*args, **opts, &block)
-      colorize(*args, **opts, fg: SuperDiff.configuration.alpha_color, &block)
+    def expected(*args, **opts, &block)
+      colorize(*args, **opts, fg: SuperDiff.configuration.expected_color, &block)
     end
 
-    def beta(*args, **opts, &block)
-      colorize(*args, **opts, fg: SuperDiff.configuration.beta_color, &block)
+    def actual(*args, **opts, &block)
+      colorize(*args, **opts, fg: SuperDiff.configuration.actual_color, &block)
     end
   end
 end

--- a/lib/super_diff/configuration.rb
+++ b/lib/super_diff/configuration.rb
@@ -1,33 +1,53 @@
 module SuperDiff
   class Configuration
     attr_reader(
+      :extra_diff_formatter_classes,
       :extra_differ_classes,
+      :extra_inspector_classes,
       :extra_operation_tree_builder_classes,
       :extra_operation_tree_classes,
-      :extra_diff_formatter_classes,
-      :extra_inspector_classes,
-      :alpha_color,
-      :beta_color,
+    )
+    attr_accessor(
+      :actual_color,
       :border_color,
+      :expected_color,
       :header_color,
     )
 
     def initialize
+      @actual_color = :yellow
+      @border_color = :blue
+      @expected_color = :magenta
+      @extra_diff_formatter_classes = [].freeze
       @extra_differ_classes = [].freeze
+      @extra_inspector_classes = [].freeze
       @extra_operation_tree_builder_classes = [].freeze
       @extra_operation_tree_classes = [].freeze
-      @extra_diff_formatter_classes = [].freeze
-      @extra_inspector_classes = [].freeze
-      @alpha_color = :magenta
-      @beta_color = :yellow
-      @border_color = :blue
       @header_color = :white
     end
+
+    def add_extra_diff_formatter_classes(*classes)
+      @extra_diff_formatter_classes =
+        (@extra_diff_formatter_classes + classes).freeze
+    end
+    alias_method(
+      :add_extra_diff_formatter_class,
+      :add_extra_diff_formatter_classes,
+    )
 
     def add_extra_differ_classes(*classes)
       @extra_differ_classes = (@extra_differ_classes + classes).freeze
     end
     alias_method :add_extra_differ_class, :add_extra_differ_classes
+
+    def add_extra_inspector_classes(*classes)
+      @extra_inspector_classes =
+        (@extra_inspector_classes + classes).freeze
+    end
+    alias_method(
+      :add_extra_inspector_class,
+      :add_extra_inspector_classes,
+    )
 
     def add_extra_operation_tree_builder_classes(*classes)
       @extra_operation_tree_builder_classes =
@@ -46,47 +66,5 @@ module SuperDiff
       :add_extra_operation_tree_class,
       :add_extra_operation_tree_classes,
     )
-
-    def add_extra_diff_formatter_classes(*classes)
-      @extra_diff_formatter_classes =
-        (@extra_diff_formatter_classes + classes).freeze
-    end
-    alias_method(
-      :add_extra_diff_formatter_class,
-      :add_extra_diff_formatter_classes,
-    )
-
-    def add_extra_inspector_classes(*classes)
-      @extra_inspector_classes =
-        (@extra_inspector_classes + classes).freeze
-    end
-    alias_method(
-      :add_extra_inspector_class,
-      :add_extra_inspector_classes,
-    )
-
-    def set_alpha_color(color)
-      @alpha_color = color
-    end
-    alias_method(
-      :set_expected_color,
-      :set_alpha_color
-    )
-
-    def set_beta_color(color)
-      @beta_color = color
-    end
-    alias_method(
-      :set_actual_color,
-      :set_beta_color
-    )
-
-    def set_border_color(color)
-      @border_color = color
-    end
-
-    def set_header_color(color)
-      @header_color = color
-    end
   end
 end

--- a/lib/super_diff/diff_formatters/collection.rb
+++ b/lib/super_diff/diff_formatters/collection.rb
@@ -4,7 +4,7 @@ module SuperDiff
       extend AttrExtras.mixin
 
       ICONS = { delete: "-", insert: "+" }.freeze
-      STYLES = { insert: :beta, delete: :alpha, noop: :plain }.freeze
+      STYLES = { insert: :actual, delete: :expected, noop: :plain }.freeze
 
       method_object(
         [

--- a/lib/super_diff/diff_formatters/multiline_string.rb
+++ b/lib/super_diff/diff_formatters/multiline_string.rb
@@ -15,12 +15,12 @@ module SuperDiff
         operation_tree.reduce([]) do |array, operation|
           case operation.name
           when :change
-            array << Helpers.style(:alpha, "- #{operation.left_value}")
-            array << Helpers.style(:beta, "+ #{operation.right_value}")
+            array << Helpers.style(:expected, "- #{operation.left_value}")
+            array << Helpers.style(:actual, "+ #{operation.right_value}")
           when :delete
-            array << Helpers.style(:alpha, "- #{operation.value}")
+            array << Helpers.style(:expected, "- #{operation.value}")
           when :insert
-            array << Helpers.style(:beta, "+ #{operation.value}")
+            array << Helpers.style(:actual, "+ #{operation.value}")
           else
             array << Helpers.style(:plain, "  #{operation.value}")
           end

--- a/lib/super_diff/equality_matchers/array.rb
+++ b/lib/super_diff/equality_matchers/array.rb
@@ -11,14 +11,14 @@ module SuperDiff
 
           #{
             Helpers.style(
-              :alpha,
+              :expected,
               "Expected: " +
               ObjectInspection.inspect(expected, as_single_line: true),
             )
           }
           #{
             Helpers.style(
-              :beta,
+              :actual,
               "  Actual: " +
               ObjectInspection.inspect(actual, as_single_line: true),
             )

--- a/lib/super_diff/equality_matchers/default.rb
+++ b/lib/super_diff/equality_matchers/default.rb
@@ -19,7 +19,7 @@ module SuperDiff
 
       def expected_line
         Helpers.style(
-          :alpha,
+          :expected,
           "Expected: " +
           ObjectInspection.inspect(expected, as_single_line: true),
         )
@@ -27,7 +27,7 @@ module SuperDiff
 
       def actual_line
         Helpers.style(
-          :beta,
+          :actual,
           "  Actual: " +
           ObjectInspection.inspect(actual, as_single_line: true),
         )

--- a/lib/super_diff/equality_matchers/hash.rb
+++ b/lib/super_diff/equality_matchers/hash.rb
@@ -11,14 +11,14 @@ module SuperDiff
 
           #{
             Helpers.style(
-              :alpha,
+              :expected,
               "Expected: " +
               ObjectInspection.inspect(expected, as_single_line: true),
             )
           }
           #{
             Helpers.style(
-              :beta,
+              :actual,
               "  Actual: " +
               ObjectInspection.inspect(actual, as_single_line: true),
             )

--- a/lib/super_diff/equality_matchers/multiline_string.rb
+++ b/lib/super_diff/equality_matchers/multiline_string.rb
@@ -12,14 +12,14 @@ module SuperDiff
           #{
             # TODO: This whole thing should not be red or green, just the values
             Helpers.style(
-              :alpha,
+              :expected,
               "Expected: " +
               ObjectInspection.inspect(expected, as_single_line: true),
             )
           }
           #{
             Helpers.style(
-              :beta,
+              :actual,
               "  Actual: " +
               ObjectInspection.inspect(actual, as_single_line: true),
             )

--- a/lib/super_diff/equality_matchers/primitive.rb
+++ b/lib/super_diff/equality_matchers/primitive.rb
@@ -15,14 +15,14 @@ module SuperDiff
 
           #{
             Helpers.style(
-              :alpha,
+              :expected,
               "Expected: " +
               ObjectInspection.inspect(expected, as_single_line: true),
             )
           }
           #{
             Helpers.style(
-              :beta,
+              :actual,
               "  Actual: " +
               ObjectInspection.inspect(actual, as_single_line: true),
             )

--- a/lib/super_diff/equality_matchers/singleline_string.rb
+++ b/lib/super_diff/equality_matchers/singleline_string.rb
@@ -11,14 +11,14 @@ module SuperDiff
 
           #{
             Helpers.style(
-              :alpha,
+              :expected,
               "Expected: " +
               ObjectInspection.inspect(expected, as_single_line: true),
             )
           }
           #{
             Helpers.style(
-              :beta,
+              :actual,
               "  Actual: " +
               ObjectInspection.inspect(actual, as_single_line: true),
             )

--- a/lib/super_diff/rspec/matcher_text_builders/base.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/base.rb
@@ -45,12 +45,12 @@ module SuperDiff
         def add_extra_after_error
         end
 
-        def beta_color
-          SuperDiff.configuration.beta_color
+        def actual_color
+          SuperDiff.configuration.actual_color
         end
 
-        def alpha_color
-          SuperDiff.configuration.alpha_color
+        def expected_color
+          SuperDiff.configuration.expected_color
         end
 
         private
@@ -91,7 +91,7 @@ module SuperDiff
         end
 
         def add_actual_value
-          template.add_text_in_color(beta_color) { actual }
+          template.add_text_in_color(actual_color) { actual }
         end
 
         def expected_section
@@ -110,7 +110,7 @@ module SuperDiff
           else
             template.add_text " "
             template.add_text_in_color(
-              alpha_color,
+              expected_color,
               expected_for_failure_message,
             )
           end
@@ -121,7 +121,7 @@ module SuperDiff
             add_expected_value_to(template, expected_for_description)
           else
             template.add_text " "
-            template.add_text_in_color(alpha_color, expected_for_description)
+            template.add_text_in_color(expected_color, expected_for_description)
           end
         end
 

--- a/lib/super_diff/rspec/matcher_text_builders/be_predicate.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/be_predicate.rb
@@ -26,12 +26,12 @@ module SuperDiff
           end
         end
 
-        def beta_color
+        def actual_color
           :yellow
         end
 
         def add_actual_value
-          template.add_text_in_color(beta_color) do
+          template.add_text_in_color(actual_color) do
             description_of(actual)
           end
         end
@@ -39,12 +39,12 @@ module SuperDiff
         def add_expected_value_to_failure_message(template)
           template.add_text " "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             "#{expected_for_failure_message}?",
           )
           template.add_text " or "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             "#{expected_for_failure_message}s?",
           )
         end
@@ -52,12 +52,12 @@ module SuperDiff
         def add_expected_value_to_description(template)
           template.add_text " "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             "`#{expected_for_description}?`",
           )
           template.add_text " or "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             "`#{expected_for_description}s?`",
           )
         end

--- a/lib/super_diff/rspec/matcher_text_builders/contain_exactly.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/contain_exactly.rb
@@ -6,7 +6,7 @@ module SuperDiff
 
         def add_expected_value_to(template, expected)
           template.add_text " "
-          template.add_list_in_color(alpha_color, expected)
+          template.add_list_in_color(expected_color, expected)
         end
       end
     end

--- a/lib/super_diff/rspec/matcher_text_builders/have_predicate.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/have_predicate.rb
@@ -20,12 +20,12 @@ module SuperDiff
           end
         end
 
-        def beta_color
+        def actual_color
           :yellow
         end
 
         def add_actual_value
-          template.add_text_in_color(beta_color) do
+          template.add_text_in_color(actual_color) do
             description_of(actual)
           end
         end
@@ -33,7 +33,7 @@ module SuperDiff
         def add_expected_value_to_failure_message(template)
           template.add_text " "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             expected_for_failure_message,
           )
         end
@@ -41,7 +41,7 @@ module SuperDiff
         def add_expected_value_to_description(template)
           template.add_text " "
           template.add_text_in_color(
-            alpha_color,
+            expected_color,
             "`#{expected_for_description}`",
           )
         end

--- a/lib/super_diff/rspec/matcher_text_builders/raise_error.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/raise_error.rb
@@ -14,7 +14,7 @@ module SuperDiff
 
         def add_actual_value
           if actual
-            template.add_text_in_color(beta_color) { actual }
+            template.add_text_in_color(actual_color) { actual }
           else
             template.add_text("block")
           end

--- a/lib/super_diff/rspec/matcher_text_builders/respond_to.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/respond_to.rb
@@ -20,7 +20,7 @@ module SuperDiff
 
         def add_expected_value_to(template, expected)
           template.add_text " "
-          template.add_list_in_color(alpha_color, expected)
+          template.add_list_in_color(expected_color, expected)
         end
 
         def add_extra_after_expected_to(template)
@@ -57,14 +57,14 @@ module SuperDiff
 
         def add_arity_clause_to(template)
           template.add_text " with "
-          template.add_text_in_color alpha_color, expected_arity
+          template.add_text_in_color expected_color, expected_arity
           template.add_text " "
           template.add_text pluralize("argument", expected_arity)
         end
 
         def add_arbitrary_keywords_clause_to(template)
           template.add_text " with "
-          template.add_text_in_color alpha_color, "any"
+          template.add_text_in_color expected_color, "any"
           template.add_text " keywords"
         end
 
@@ -72,7 +72,7 @@ module SuperDiff
           template.add_text " with "
           template.add_text pluralize("keyword", expected_keywords.length)
           template.add_text " "
-          template.add_list_in_color alpha_color, expected_keywords
+          template.add_list_in_color expected_color, expected_keywords
         end
 
         def add_unlimited_arguments_clause_to(template)
@@ -82,7 +82,7 @@ module SuperDiff
             template.add_text " with "
           end
 
-          template.add_text_in_color alpha_color, "unlimited"
+          template.add_text_in_color expected_color, "unlimited"
           template.add_text " arguments"
         end
 

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -283,14 +283,14 @@ module RSpec
           colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
           colorizer.wrap(
             "‹-› in expected, not in actual",
-            SuperDiff.configuration.alpha_color
+            SuperDiff.configuration.expected_color
           ) +
           colorizer.wrap("  │", SuperDiff.configuration.border_color) +
           "\n" +
           colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
           colorizer.wrap(
             "‹+› in actual, not in expected",
-            SuperDiff.configuration.beta_color
+            SuperDiff.configuration.actual_color
           ) +
           colorizer.wrap("  │", SuperDiff.configuration.border_color) +
           "\n" +

--- a/spec/integration/rspec/be_falsey_matcher_spec.rb
+++ b/spec/integration/rspec/be_falsey_matcher_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "Integration with RSpec's #be_falsey matcher", type: :integration
         snippet: snippet,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|:foo|
-            plain " to be "
-            alpha %|falsey|
-            plain "."
+            plain    %|Expected |
+            actual   %|:foo|
+            plain    %| to be |
+            expected %|falsey|
+            plain    %|.|
           end
         },
       )
@@ -36,11 +36,11 @@ RSpec.describe "Integration with RSpec's #be_falsey matcher", type: :integration
         snippet: snippet,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|false|
-            plain " not to be "
-            alpha %|falsey|
-            plain "."
+            plain    %|Expected |
+            actual   %|false|
+            plain    %| not to be |
+            expected %|falsey|
+            plain    %|.|
           end
         },
       )

--- a/spec/integration/rspec/be_matcher_spec.rb
+++ b/spec/integration/rspec/be_matcher_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
             snippet: %|expect(true).to be(false)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|true|
-                plain " to equal "
-                alpha %|false|
-                plain "."
+                plain    %|Expected |
+                actual   %|true|
+                plain    %| to equal |
+                expected %|false|
+                plain    %|.|
               end
             },
           )
@@ -42,11 +42,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
             snippet: %|expect(false).not_to be(false)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|false|
-                plain " not to equal "
-                alpha %|false|
-                plain "."
+                plain    %|Expected |
+                actual   %|false|
+                plain    %| not to equal |
+                expected %|false|
+                plain    %|.|
               end
             },
           )
@@ -71,11 +71,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
             snippet: %|expect(false).to be(true)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|false|
-                plain " to equal "
-                alpha %|true|
-                plain "."
+                plain    %|Expected |
+                actual   %|false|
+                plain    %| to equal |
+                expected %|true|
+                plain    %|.|
               end
             },
           )
@@ -98,11 +98,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
             snippet: %|expect(true).not_to be(true)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|true|
-                plain " not to equal "
-                alpha %|true|
-                plain "."
+                plain    %|Expected |
+                actual   %|true|
+                plain    %| not to equal |
+                expected %|true|
+                plain    %|.|
               end
             },
           )
@@ -128,11 +128,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(nil).to be|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|nil|
-              plain " to be "
-              alpha %|truthy|
-              plain "."
+              plain    %|Expected |
+              actual   %|nil|
+              plain    %| to be |
+              expected %|truthy|
+              plain    %|.|
             end
           },
         )
@@ -155,11 +155,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(:something).not_to be|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|:something|
-              plain " not to be "
-              alpha %|truthy|
-              plain "."
+              plain    %|Expected |
+              actual   %|:something|
+              plain    %| not to be |
+              expected %|truthy|
+              plain    %|.|
             end
           },
         )
@@ -184,11 +184,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(nil).to be == :foo|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|nil|
-              plain " to == "
-              alpha %|:foo|
-              plain "."
+              plain    %|Expected |
+              actual   %|nil|
+              plain    %| to == |
+              expected %|:foo|
+              plain    %|.|
             end
           },
         )
@@ -211,11 +211,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(:foo).not_to be == :foo|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|:foo|
-              plain " not to == "
-              alpha %|:foo|
-              plain "."
+              plain    %|Expected |
+              actual   %|:foo|
+              plain    %| not to == |
+              expected %|:foo|
+              plain    %|.|
             end
           },
         )
@@ -240,11 +240,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(1).to be < 1|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|1|
-              plain " to be < "
-              alpha %|1|
-              plain "."
+              plain    %|Expected |
+              actual   %|1|
+              plain    %| to be < |
+              expected %|1|
+              plain    %|.|
             end
           },
         )
@@ -267,11 +267,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(0).not_to be < 1|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|0|
-              plain " not to be < "
-              alpha %|1|
-              plain "."
+              plain    %|Expected |
+              actual   %|0|
+              plain    %| not to be < |
+              expected %|1|
+              plain    %|.|
             end
           },
         )
@@ -296,11 +296,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(1).to be <= 0|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|1|
-              plain " to be <= "
-              alpha %|0|
-              plain "."
+              plain    %|Expected |
+              actual   %|1|
+              plain    %| to be <= |
+              expected %|0|
+              plain    %|.|
             end
           },
         )
@@ -323,11 +323,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(0).not_to be <= 0|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|0|
-              plain " not to be <= "
-              alpha %|0|
-              plain "."
+              plain    %|Expected |
+              actual   %|0|
+              plain    %| not to be <= |
+              expected %|0|
+              plain    %|.|
             end
           },
         )
@@ -352,11 +352,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(1).to be >= 2|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|1|
-              plain " to be >= "
-              alpha %|2|
-              plain "."
+              plain    %|Expected |
+              actual   %|1|
+              plain    %| to be >= |
+              expected %|2|
+              plain    %|.|
             end
           },
         )
@@ -379,11 +379,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(2).not_to be >= 2|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|2|
-              plain " not to be >= "
-              alpha %|2|
-              plain "."
+              plain    %|Expected |
+              actual   %|2|
+              plain    %| not to be >= |
+              expected %|2|
+              plain    %|.|
             end
           },
         )
@@ -408,11 +408,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(1).to be > 2|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|1|
-              plain " to be > "
-              alpha %|2|
-              plain "."
+              plain    %|Expected |
+              actual   %|1|
+              plain    %| to be > |
+              expected %|2|
+              plain    %|.|
             end
           },
         )
@@ -435,11 +435,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(3).not_to be > 2|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|3|
-              plain " not to be > "
-              alpha %|2|
-              plain "."
+              plain    %|Expected |
+              actual   %|3|
+              plain    %| not to be > |
+              expected %|2|
+              plain    %|.|
             end
           },
         )
@@ -464,11 +464,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(String).to be === :foo|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|String|
-              plain " to === "
-              alpha %|:foo|
-              plain "."
+              plain    %|Expected |
+              actual   %|String|
+              plain    %| to === |
+              expected %|:foo|
+              plain    %|.|
             end
           },
         )
@@ -491,11 +491,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect(String).not_to be === "foo"|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|String|
-              plain " not to === "
-              alpha %|"foo"|
-              plain "."
+              plain    %|Expected |
+              actual   %|String|
+              plain    %| not to === |
+              expected %|"foo"|
+              plain    %|.|
             end
           },
         )
@@ -520,11 +520,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect("foo").to be =~ /bar/|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"foo"|
-              plain " to =~ "
-              alpha %|/bar/|
-              plain "."
+              plain    %|Expected |
+              actual   %|"foo"|
+              plain    %| to =~ |
+              expected %|/bar/|
+              plain    %|.|
             end
           },
         )
@@ -547,11 +547,11 @@ RSpec.describe "Integration with RSpec's #be matcher", type: :integration do
           snippet: %|expect("bar").not_to be =~ /bar/|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"bar"|
-              plain " not to =~ "
-              alpha %|/bar/|
-              plain "."
+              plain    %|Expected |
+              actual   %|"bar"|
+              plain    %| not to =~ |
+              expected %|/bar/|
+              plain    %|.|
             end
           },
         )

--- a/spec/integration/rspec/be_nil_matcher_spec.rb
+++ b/spec/integration/rspec/be_nil_matcher_spec.rb
@@ -11,11 +11,11 @@ RSpec.describe "Integration with RSpec's #be_nil matcher", type: :integration do
         snippet: %|expect(:foo).to be_nil|,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|:foo|
-            plain " to be "
-            alpha %|nil|
-            plain "."
+            plain    %|Expected |
+            actual   %|:foo|
+            plain    %| to be |
+            expected %|nil|
+            plain    %|.|
           end
         },
       )
@@ -36,11 +36,11 @@ RSpec.describe "Integration with RSpec's #be_nil matcher", type: :integration do
         snippet: %|expect(nil).not_to be_nil|,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|nil|
-            plain " not to be "
-            alpha %|nil|
-            plain "."
+            plain    %|Expected |
+            actual   %|nil|
+            plain    %| not to be |
+            expected %|nil|
+            plain    %|.|
           end
         },
       )

--- a/spec/integration/rspec/be_predicate_matcher_spec.rb
+++ b/spec/integration/rspec/be_predicate_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
   # rubocop:enable Metrics/BlockLength
     context "using #{prefix}_<predicate>" do
       context "when the predicate method doesn't exist on the object" do
-        context "when the inspected version of the actual value is short" do
+        context "when the inspected version of the actual   value is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = %|expect(:foo).to #{prefix}_strong|
@@ -20,13 +20,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                 snippet: snippet,
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|:foo|
-                    plain " to respond to "
-                    alpha %|strong?|
-                    plain " or "
-                    alpha %|strongs?|
-                    plain "."
+                    plain    %|Expected |
+                    actual   %|:foo|
+                    plain    %| to respond to |
+                    expected %|strong?|
+                    plain    %| or |
+                    expected %|strongs?|
+                    plain    %|.|
                   end
                 },
               )
@@ -38,7 +38,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
           end
         end
 
-        context "when the inspected version of the actual value is long" do
+        context "when the inspected version of the actual   value is long" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -56,15 +56,15 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "     Expected "
-                    beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
+                    plain    %|     Expected |
+                    actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
                   end
 
                   line do
-                    plain "to respond to "
-                    alpha %|strong?|
-                    plain " or "
-                    alpha %|strongs?|
+                    plain    %|to respond to |
+                    expected %|strong?|
+                    plain    %| or |
+                    expected %|strongs?|
                   end
                 },
               )
@@ -79,7 +79,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
 
       context "when the predicate method exists on the object" do
         context "but is private" do
-          context "when the inspected version of the actual value is short" do
+          context "when the inspected version of the actual   value is short" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -99,13 +99,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                   snippet: %|expect(Foo.new).to #{prefix}_strong|,
                   expectation: proc {
                     line do
-                      plain "Expected "
-                      beta %|#<Foo>|
-                      plain " to have a public method "
-                      alpha %|strong?|
-                      plain " or "
-                      alpha %|strongs?|
-                      plain "."
+                      plain    %|Expected |
+                      actual   %|#<Foo>|
+                      plain    %| to have a public method |
+                      expected %|strong?|
+                      plain    %| or |
+                      expected %|strongs?|
+                      plain    %|.|
                     end
                   },
                 )
@@ -118,7 +118,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
             end
           end
 
-          context "when the inspected version of the actual value is long" do
+          context "when the inspected version of the actual   value is long" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -141,15 +141,15 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "               Expected "
-                      beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz" }|
+                      plain    %|               Expected |
+                      actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz" }|
                     end
 
                     line do
-                      plain "to have a public method "
-                      alpha %|strong?|
-                      plain " or "
-                      alpha %|strongs?|
+                      plain    %|to have a public method |
+                      expected %|strong?|
+                      plain    %| or |
+                      expected %|strongs?|
                     end
                   },
                 )
@@ -166,7 +166,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
         context "and is public" do
           context "and returns false" do
             context "but is called #true?" do
-              context "when the inspected version of the actual value is short" do
+              context "when the inspected version of the actual   value is short" do
                 it "produces the correct failure message" do
                   as_both_colored_and_uncolored do |color_enabled|
                     snippet = <<~TEST.strip
@@ -187,23 +187,23 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                       newline_before_expectation: true,
                       expectation: proc {
                         line do
-                          plain "Expected "
-                          beta %|#<Foo>|
-                          plain " to return a truthy result for "
-                          alpha %|true?|
-                          plain " or "
-                          alpha %|trues?|
-                          plain "."
+                          plain    %|Expected |
+                          actual   %|#<Foo>|
+                          plain    %| to return a truthy result for |
+                          expected %|true?|
+                          plain    %| or |
+                          expected %|trues?|
+                          plain    %|.|
                         end
 
                         newline
 
                         line do
-                          plain "(Perhaps you want to use "
+                          plain    %|(Perhaps you want to use |
                           blue "be(true)"
-                          plain " or "
+                          plain    %| or |
                           blue "be_truthy"
-                          plain " instead?)"
+                          plain    %| instead?)|
                         end
                       },
                     )
@@ -216,7 +216,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                 end
               end
 
-              context "when the inspected version of the actual value is long" do
+              context "when the inspected version of the actual   value is long" do
                 it "produces the correct failure message" do
                   as_both_colored_and_uncolored do |color_enabled|
                     snippet = <<~TEST.strip
@@ -244,25 +244,25 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                       newline_before_expectation: true,
                       expectation: proc {
                         line do
-                          plain "                     Expected "
-                          beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz" }|
+                          plain    %|                     Expected |
+                          actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz" }|
                         end
 
                         line do
-                          plain "to return a truthy result for "
-                          alpha %|true?|
-                          plain " or "
-                          alpha %|trues?|
+                          plain    %|to return a truthy result for |
+                          expected %|true?|
+                          plain    %| or |
+                          expected %|trues?|
                         end
 
                         newline
 
                         line do
-                          plain "(Perhaps you want to use "
+                          plain    %|(Perhaps you want to use |
                           blue "be(true)"
-                          plain " or "
+                          plain    %| or |
                           blue "be_truthy"
-                          plain " instead?)"
+                          plain    %| instead?)|
                         end
                       },
                     )
@@ -297,13 +297,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                     newline_before_expectation: true,
                     expectation: proc {
                       line do
-                        plain "Expected "
-                        beta %|#<X>|
-                        plain " to return a truthy result for "
-                        alpha %|false?|
-                        plain " or "
-                        alpha %|falses?|
-                        plain "."
+                        plain    %|Expected |
+                        actual   %|#<X>|
+                        plain    %| to return a truthy result for |
+                        expected %|false?|
+                        plain    %| or |
+                        expected %|falses?|
+                        plain    %|.|
                       end
                     },
                   )
@@ -318,7 +318,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
 
             context "and is called neither #true? nor #false?" do
               context "and is singular" do
-                context "when the inspected version of the actual value is short" do
+                context "when the inspected version of the actual   value is short" do
                   it "produces the correct failure message" do
                     as_both_colored_and_uncolored do |color_enabled|
                       snippet = <<~TEST.strip
@@ -338,13 +338,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                         snippet: %|expect(X.new).to #{prefix}_y|,
                         expectation: proc {
                           line do
-                            plain "Expected "
-                            beta %|#<X>|
-                            plain " to return a truthy result for "
-                            alpha %|y?|
-                            plain " or "
-                            alpha %|ys?|
-                            plain "."
+                            plain    %|Expected |
+                            actual   %|#<X>|
+                            plain    %| to return a truthy result for |
+                            expected %|y?|
+                            plain    %| or |
+                            expected %|ys?|
+                            plain    %|.|
                           end
                         },
                       )
@@ -357,7 +357,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                   end
                 end
 
-                context "when the inspected version of the actual value is long" do
+                context "when the inspected version of the actual   value is long" do
                   it "produces the correct failure message" do
                     as_both_colored_and_uncolored do |color_enabled|
                       snippet = <<~TEST.strip
@@ -386,15 +386,15 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                         newline_before_expectation: true,
                         expectation: proc {
                           line do
-                            plain "                     Expected "
-                            beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
+                            plain    %|                     Expected |
+                            actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
                           end
 
                           line do
-                            plain "to return a truthy result for "
-                            alpha %|y?|
-                            plain " or "
-                            alpha %|ys?|
+                            plain    %|to return a truthy result for |
+                            expected %|y?|
+                            plain    %| or |
+                            expected %|ys?|
                           end
                         },
                       )
@@ -409,7 +409,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
               end
 
               context "and is plural" do
-                context "when the inspected version of the actual value is short" do
+                context "when the inspected version of the actual   value is short" do
                   it "produces the correct failure message" do
                     as_both_colored_and_uncolored do |color_enabled|
                       snippet = <<~TEST.strip
@@ -429,13 +429,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                         snippet: %|expect(X.new).to #{prefix}_y|,
                         expectation: proc {
                           line do
-                            plain "Expected "
-                            beta %|#<X>|
-                            plain " to return a truthy result for "
-                            alpha %|y?|
-                            plain " or "
-                            alpha %|ys?|
-                            plain "."
+                            plain    %|Expected |
+                            actual   %|#<X>|
+                            plain    %| to return a truthy result for |
+                            expected %|y?|
+                            plain    %| or |
+                            expected %|ys?|
+                            plain    %|.|
                           end
                         },
                       )
@@ -448,7 +448,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                   end
                 end
 
-                context "when the inspected version of the actual value is long" do
+                context "when the inspected version of the actual   value is long" do
                   it "produces the correct failure message" do
                     as_both_colored_and_uncolored do |color_enabled|
                       snippet = <<~TEST.strip
@@ -477,15 +477,15 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                         newline_before_expectation: true,
                         expectation: proc {
                           line do
-                            plain "                     Expected "
-                            beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
+                            plain    %|                     Expected |
+                            actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
                           end
 
                           line do
-                            plain "to return a truthy result for "
-                            alpha %|y?|
-                            plain " or "
-                            alpha %|ys?|
+                            plain    %|to return a truthy result for |
+                            expected %|y?|
+                            plain    %| or |
+                            expected %|ys?|
                           end
                         },
                       )
@@ -502,7 +502,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
           end
 
           context "and returns true" do
-            context "when the inspected version of the actual value is short" do
+            context "when the inspected version of the actual   value is short" do
               it "produces the correct failure message when used in the negative" do
                 as_both_colored_and_uncolored do |color_enabled|
                   snippet = <<~TEST.strip
@@ -522,13 +522,13 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                     snippet: %|expect(Foo.new).not_to #{prefix}_strong|,
                     expectation: proc {
                       line do
-                        plain "Expected "
-                        beta %|#<Foo>|
-                        plain " not to return a truthy result for "
-                        alpha %|strong?|
-                        plain " or "
-                        alpha %|strongs?|
-                        plain "."
+                        plain    %|Expected |
+                        actual   %|#<Foo>|
+                        plain    %| not to return a truthy result for |
+                        expected %|strong?|
+                        plain    %| or |
+                        expected %|strongs?|
+                        plain    %|.|
                       end
                     },
                   )
@@ -541,7 +541,7 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
               end
             end
 
-            context "when the inspected version of the actual value is long" do
+            context "when the inspected version of the actual   value is long" do
               it "produces the correct failure message when used in the negative" do
                 as_both_colored_and_uncolored do |color_enabled|
                   snippet = <<~TEST.strip
@@ -570,15 +570,15 @@ RSpec.describe "Integration with RSpec's #be_<predicate> matcher", type: :integr
                     newline_before_expectation: true,
                     expectation: proc {
                       line do
-                        plain "                         Expected "
-                        beta %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
+                        plain    %|                         Expected |
+                        actual   %|{ foo: "bar", baz: "qux", blargh: "foz", fizz: "buzz", aaaaaa: "bbbbbb" }|
                       end
 
                       line do
-                        plain "not to return a truthy result for "
-                        alpha %|y?|
-                        plain " or "
-                        alpha %|ys?|
+                        plain    %|not to return a truthy result for |
+                        expected %|y?|
+                        plain    %| or |
+                        expected %|ys?|
                       end
                     },
                   )

--- a/spec/integration/rspec/be_truthy_matcher_spec.rb
+++ b/spec/integration/rspec/be_truthy_matcher_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe "Integration with RSpec's #be_truthy matcher", type: :integration
         snippet: %|expect(nil).to be_truthy|,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|nil|
-            plain " to be "
-            alpha %|truthy|
-            plain "."
+            plain    %|Expected |
+            actual   %|nil|
+            plain    %| to be |
+            expected %|truthy|
+            plain    %|.|
           end
         },
       )
@@ -40,11 +40,11 @@ RSpec.describe "Integration with RSpec's #be_truthy matcher", type: :integration
         snippet: %|expect(true).not_to be_truthy|,
         expectation: proc {
           line do
-            plain "Expected "
-            beta %|true|
-            plain " not to be "
-            alpha %|truthy|
-            plain "."
+            plain    %|Expected |
+            actual   %|true|
+            plain    %| not to be |
+            expected %|truthy|
+            plain    %|.|
           end
         },
       )

--- a/spec/integration/rspec/contain_exactly_matcher_spec.rb
+++ b/spec/integration/rspec/contain_exactly_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = ["Einie", "Marty"]
-          actual = ["Marty", "Jennifer", "Doc"]
+          actual   = ["Marty", "Jennifer", "Doc"]
           expect(actual).to contain_exactly(*expected)
         TEST
         program = make_plain_test_program(
@@ -19,22 +19,22 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
           snippet: %|expect(actual).to contain_exactly(*expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|["Marty", "Jennifer", "Doc"]|
-              plain " to contain exactly "
-              alpha %|"Einie"|
-              plain " and "
-              alpha %|"Marty"|
-              plain "."
+              plain    %|Expected |
+              actual   %|["Marty", "Jennifer", "Doc"]|
+              plain    %| to contain exactly |
+              expected %|"Einie"|
+              plain    %| and |
+              expected %|"Marty"|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  [|
-            plain_line %|    "Marty",|
-            beta_line  %|+   "Jennifer",|
-            beta_line  %|+   "Doc",|
-            alpha_line %|-   "Einie"|
-            plain_line %|  ]|
+            plain_line    %|  [|
+            plain_line    %|    "Marty",|
+            actual_line   %|+   "Jennifer",|
+            actual_line   %|+   "Doc",|
+            expected_line %|-   "Einie"|
+            plain_line    %|  ]|
           },
         )
 
@@ -60,13 +60,13 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
           snippet: %|expect(values).not_to contain_exactly(*values)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|["Einie", "Marty"]|
-              plain " not to contain exactly "
-              alpha %|"Einie"|
-              plain " and "
-              alpha %|"Marty"|
-              plain "."
+              plain    %|Expected |
+              actual   %|["Einie", "Marty"]|
+              plain    %| not to contain exactly |
+              expected %|"Einie"|
+              plain    %| and |
+              expected %|"Marty"|
+              plain    %|.|
             end
           },
         )
@@ -90,7 +90,7 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               "George McFly",
               "Lorraine McFly"
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -108,32 +108,32 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
             snippet: %|expect(actual).to contain_exactly(*expected)|,
             expectation: proc {
               line do
-                plain "          Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|          Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "to contain exactly "
-                alpha %|"Doc Brown"|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|"George McFly"|
-                plain " and "
-                alpha %|"Lorraine McFly"|
+                plain    %|to contain exactly |
+                expected %|"Doc Brown"|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|"George McFly"|
+                plain    %| and |
+                expected %|"Lorraine McFly"|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty McFly",|
-              plain_line %|    "Doc Brown",|
-              plain_line %|    "Lorraine McFly",|
-              beta_line  %|+   "Einie",|
-              alpha_line %|-   "Biff Tannen",|
-              alpha_line %|-   "George McFly"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty McFly",|
+              plain_line    %|    "Doc Brown",|
+              plain_line    %|    "Lorraine McFly",|
+              actual_line   %|+   "Einie",|
+              expected_line %|-   "Biff Tannen",|
+              expected_line %|-   "George McFly"|
+              plain_line    %|  ]|
             },
           )
 
@@ -165,19 +165,19 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "              Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|              Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "not to contain exactly "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Doc Brown"|
-                plain ", "
-                alpha %|"Einie"|
-                plain " and "
-                alpha %|"Lorraine McFly"|
+                plain    %|not to contain exactly |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Doc Brown"|
+                plain    %|, |
+                expected %|"Einie"|
+                plain    %| and |
+                expected %|"Lorraine McFly"|
               end
             },
           )
@@ -200,7 +200,7 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               /Georg McFly/,
               /Lorrain McFly/
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -218,33 +218,33 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
             snippet: %|expect(actual).to contain_exactly(*expected)|,
             expectation: proc {
               line do
-                plain "          Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|          Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "to contain exactly "
-                alpha %|/ Brown$/|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|/Georg McFly/|
-                plain " and "
-                alpha %|/Lorrain McFly/|
+                plain    %|to contain exactly |
+                expected %|/ Brown$/|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|/Georg McFly/|
+                plain    %| and |
+                expected %|/Lorrain McFly/|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty McFly",|
-              plain_line %|    "Doc Brown",|
-              beta_line  %|+   "Einie",|
-              beta_line  %|+   "Lorraine McFly",|
-              alpha_line %|-   "Biff Tannen",|
-              alpha_line %|-   /Georg McFly/,|
-              alpha_line %|-   /Lorrain McFly/|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty McFly",|
+              plain_line    %|    "Doc Brown",|
+              actual_line   %|+   "Einie",|
+              actual_line   %|+   "Lorraine McFly",|
+              expected_line %|-   "Biff Tannen",|
+              expected_line %|-   /Georg McFly/,|
+              expected_line %|-   /Lorrain McFly/|
+              plain_line    %|  ]|
             },
           )
 
@@ -277,21 +277,21 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "              Expected "
-                beta %|[/ Brown$/, "Marty McFly", "Biff Tannen", /Georg McFly/, /Lorrain McFly/]|
+                plain    %|              Expected |
+                actual   %|[/ Brown$/, "Marty McFly", "Biff Tannen", /Georg McFly/, /Lorrain McFly/]|
               end
 
               line do
-                plain "not to contain exactly "
-                alpha %|/ Brown$/|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|/Georg McFly/|
-                plain " and "
-                alpha %|/Lorrain McFly/|
+                plain    %|not to contain exactly |
+                expected %|/ Brown$/|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|/Georg McFly/|
+                plain    %| and |
+                expected %|/Lorrain McFly/|
               end
             },
           )
@@ -312,7 +312,7 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
               a_collection_containing_exactly("zing"),
               an_object_having_attributes(baz: "qux"),
             ]
-            actual = [
+            actual   = [
               { foo: "bar" },
               double(baz: "qux"),
               { blargh: "riddle" }
@@ -329,32 +329,32 @@ RSpec.describe "Integration with RSpec's #contain_exactly matcher", type: :integ
             snippet: %|expect(actual).to contain_exactly(*expected)|,
             expectation: proc {
               line do
-                plain "          Expected "
-                beta %|[{ foo: "bar" }, #<Double (anonymous)>, { blargh: "riddle" }]|
+                plain    %|          Expected |
+                actual   %|[{ foo: "bar" }, #<Double (anonymous)>, { blargh: "riddle" }]|
               end
 
               line do
-                plain "to contain exactly "
-                alpha %|#<a hash including (foo: "bar")>|
-                plain ", "
-                alpha %|#<a collection containing exactly ("zing")>|
-                plain " and "
-                alpha %|#<an object having attributes (baz: "qux")>|
+                plain    %|to contain exactly |
+                expected %|#<a hash including (foo: "bar")>|
+                plain    %|, |
+                expected %|#<a collection containing exactly ("zing")>|
+                plain    %| and |
+                expected %|#<an object having attributes (baz: "qux")>|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    {|
-              plain_line %|      foo: "bar"|
-              plain_line %|    },|
-              plain_line %|    #<Double (anonymous)>,|
-              beta_line  %|+   {|
-              beta_line  %|+     blargh: "riddle"|
-              beta_line  %|+   },|
-              alpha_line %|-   #<a collection containing exactly (|
-              alpha_line %|-     "zing"|
-              alpha_line %|-   )>|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    {|
+              plain_line    %|      foo: "bar"|
+              plain_line    %|    },|
+              plain_line    %|    #<Double (anonymous)>,|
+              actual_line   %|+   {|
+              actual_line   %|+     blargh: "riddle"|
+              actual_line   %|+   },|
+              expected_line %|-   #<a collection containing exactly (|
+              expected_line %|-     "zing"|
+              expected_line %|-   )>|
+              plain_line    %|  ]|
             },
           )
 

--- a/spec/integration/rspec/eq_matcher_spec.rb
+++ b/spec/integration/rspec/eq_matcher_spec.rb
@@ -12,11 +12,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: snippet,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|1|
-              plain " to eq "
-              alpha %|42|
-              plain "."
+              plain    %|Expected |
+              actual   %|1|
+              plain    %| to eq |
+              expected %|42|
+              plain    %|.|
             end
           },
         )
@@ -37,11 +37,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: snippet,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|42|
-              plain " not to eq "
-              alpha %|42|
-              plain "."
+              plain    %|Expected |
+              actual   %|42|
+              plain    %| not to eq |
+              expected %|42|
+              plain    %|.|
             end
           },
         )
@@ -67,11 +67,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: snippet,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|:bar|
-              plain " to eq "
-              alpha %|:foo|
-              plain "."
+              plain    %|Expected |
+              actual   %|:bar|
+              plain    %| to eq |
+              expected %|:foo|
+              plain    %|.|
             end
           },
         )
@@ -95,11 +95,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: snippet,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|:foo|
-              plain " not to eq "
-              alpha %|:foo|
-              plain "."
+              plain    %|Expected |
+              actual   %|:foo|
+              plain    %| not to eq |
+              expected %|:foo|
+              plain    %|.|
             end
           },
         )
@@ -125,11 +125,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect("Jennifer").to eq("Marty")|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"Jennifer"|
-              plain " to eq "
-              alpha %|"Marty"|
-              plain "."
+              plain    %|Expected |
+              actual   %|"Jennifer"|
+              plain    %| to eq |
+              expected %|"Marty"|
+              plain    %|.|
             end
           },
         )
@@ -153,11 +153,11 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect("Jennifer").not_to eq("Jennifer")|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"Jennifer"|
-              plain " not to eq "
-              alpha %|"Jennifer"|
-              plain "."
+              plain    %|Expected |
+              actual   %|"Jennifer"|
+              plain    %| not to eq |
+              expected %|"Jennifer"|
+              plain    %|.|
             end
           },
         )
@@ -174,7 +174,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~RUBY
           expected = Time.utc(2011, 12, 13, 14, 15, 16)
-          actual = Time.utc(2011, 12, 13, 14, 15, 16, 500_000)
+          actual   = Time.utc(2011, 12, 13, 14, 15, 16, 500_000)
           expect(expected).to eq(actual)
         RUBY
         program = make_plain_test_program(
@@ -187,26 +187,26 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(expected).to eq(actual)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
-              plain " to eq "
-              alpha %|2011-12-13 14:15:16.500 UTC +00:00 (Time)|
-              plain "."
+              plain    %|Expected |
+              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              plain    %| to eq |
+              expected %|2011-12-13 14:15:16.500 UTC +00:00 (Time)|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line "  #<Time {"
-            plain_line "    year: 2011,"
-            plain_line "    month: 12,"
-            plain_line "    day: 13,"
-            plain_line "    hour: 14,"
-            plain_line "    min: 15,"
-            plain_line "    sec: 16,"
-            alpha_line "-   nsec: 500000000,"
-            beta_line  "+   nsec: 0,"
-            plain_line "    zone: \"UTC\","
-            plain_line "    gmt_offset: 0"
-            plain_line "  }>"
+            plain_line    "  #<Time {"
+            plain_line    "    year: 2011,"
+            plain_line    "    month: 12,"
+            plain_line    "    day: 13,"
+            plain_line    "    hour: 14,"
+            plain_line    "    min: 15,"
+            plain_line    "    sec: 16,"
+            expected_line "-   nsec: 500000000,"
+            actual_line   "+   nsec: 0,"
+            plain_line    "    zone: \"UTC\","
+            plain_line    "    gmt_offset: 0"
+            plain_line    "  }>"
           },
         )
 
@@ -233,13 +233,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain " Expected "
-              beta %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              plain    %| Expected |
+              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
             end
 
             line do
-              plain "not to eq "
-              alpha %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              plain    %|not to eq |
+              expected %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
             end
           },
         )
@@ -256,7 +256,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~RUBY
           expected = Time.utc(2011, 12, 13, 14, 15, 16)
-          actual = Time.utc(2011, 12, 13, 15, 15, 16).in_time_zone("Europe/Stockholm")
+          actual   = Time.utc(2011, 12, 13, 15, 15, 16).in_time_zone("Europe/Stockholm")
           expect(expected).to eq(actual)
         RUBY
         program = make_rspec_rails_test_program(
@@ -269,32 +269,32 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(expected).to eq(actual)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              plain    %|Expected |
+              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
             end
 
             line do
-              plain "   to eq "
-              alpha %|2011-12-13 16:15:16.000 CET +01:00 (ActiveSupport::TimeWithZone)|
+              plain    %|   to eq |
+              expected %|2011-12-13 16:15:16.000 CET +01:00 (ActiveSupport::TimeWithZone)|
             end
           },
           diff: proc {
-            plain_line "  #<ActiveSupport::TimeWithZone {"
-            plain_line "    year: 2011,"
-            plain_line "    month: 12,"
-            plain_line "    day: 13,"
-            alpha_line "-   hour: 16,"
-            beta_line  "+   hour: 14,"
-            plain_line "    min: 15,"
-            plain_line "    sec: 16,"
-            plain_line "    nsec: 0,"
-            alpha_line "-   zone: \"CET\","
-            beta_line  "+   zone: \"UTC\","
-            alpha_line "-   gmt_offset: 3600,"
-            beta_line  "+   gmt_offset: 0,"
-            alpha_line "-   utc: 2011-12-13 15:15:16.000 UTC +00:00 (Time)"
-            beta_line  "+   utc: 2011-12-13 14:15:16.000 UTC +00:00 (Time)"
-            plain_line "  }>"
+            plain_line    "  #<ActiveSupport::TimeWithZone {"
+            plain_line    "    year: 2011,"
+            plain_line    "    month: 12,"
+            plain_line    "    day: 13,"
+            expected_line "-   hour: 16,"
+            actual_line   "+   hour: 14,"
+            plain_line    "    min: 15,"
+            plain_line    "    sec: 16,"
+            plain_line    "    nsec: 0,"
+            expected_line "-   zone: \"CET\","
+            actual_line   "+   zone: \"UTC\","
+            expected_line "-   gmt_offset: 3600,"
+            actual_line   "+   gmt_offset: 0,"
+            expected_line "-   utc: 2011-12-13 15:15:16.000 UTC +00:00 (Time)"
+            actual_line   "+   utc: 2011-12-13 14:15:16.000 UTC +00:00 (Time)"
+            plain_line    "  }>"
           },
         )
 
@@ -310,7 +310,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = "Something entirely different"
-          actual = "This is a line\\nAnd that's another line\\n"
+          actual   = "This is a line\\nAnd that's another line\\n"
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -320,17 +320,17 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(actual).to eq(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"This is a line\\nAnd that's another line\\n"|
-              plain " to eq "
-              alpha %|"Something entirely different"|
-              plain "."
+              plain    %|Expected |
+              actual   %|"This is a line\\nAnd that's another line\\n"|
+              plain    %| to eq |
+              expected %|"Something entirely different"|
+              plain    %|.|
             end
           },
           diff: proc {
-            alpha_line %|- Something entirely different|
-            beta_line  %|+ This is a line\\n|
-            beta_line  %|+ And that's another line\\n|
+            expected_line %|- Something entirely different|
+            actual_line   %|+ This is a line\\n|
+            actual_line   %|+ And that's another line\\n|
           },
         )
 
@@ -346,7 +346,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = "This is a line\\nAnd that's another line\\n"
-          actual = "Something entirely different"
+          actual   = "Something entirely different"
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -356,17 +356,17 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(actual).to eq(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"Something entirely different"|
-              plain " to eq "
-              alpha %|"This is a line\\nAnd that's another line\\n"|
-              plain "."
+              plain    %|Expected |
+              actual   %|"Something entirely different"|
+              plain    %| to eq |
+              expected %|"This is a line\\nAnd that's another line\\n"|
+              plain    %|.|
             end
           },
           diff: proc {
-            alpha_line %|- This is a line\\n|
-            alpha_line %|- And that's another line\\n|
-            beta_line  %|+ Something entirely different|
+            expected_line %|- This is a line\\n|
+            expected_line %|- And that's another line\\n|
+            actual_line   %|+ Something entirely different|
           },
         )
 
@@ -382,7 +382,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = "This is a line\\nAnd that's a line\\nAnd there's a line too\\n"
-          actual = "This is a line\\nSomething completely different\\nAnd there's a line too\\n"
+          actual   = "This is a line\\nSomething completely different\\nAnd there's a line too\\n"
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -392,20 +392,20 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(actual).to eq(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|"This is a line\\nSomething completely different\\nAnd there's a line too\\n"|
+              plain    %|Expected |
+              actual   %|"This is a line\\nSomething completely different\\nAnd there's a line too\\n"|
             end
 
             line do
-              plain "   to eq "
-              alpha %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
+              plain    %|   to eq |
+              expected %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
             end
           },
           diff: proc {
-            plain_line %|  This is a line\\n|
-            alpha_line %|- And that's a line\\n|
-            beta_line  %|+ Something completely different\\n|
-            plain_line %|  And there's a line too\\n|
+            plain_line    %|  This is a line\\n|
+            expected_line %|- And that's a line\\n|
+            actual_line   %|+ Something completely different\\n|
+            plain_line    %|  And there's a line too\\n|
           },
         )
 
@@ -429,13 +429,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain " Expected "
-              beta %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
+              plain    %| Expected |
+              actual   %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
             end
 
             line do
-              plain "not to eq "
-              alpha %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
+              plain    %|not to eq |
+              expected %|"This is a line\\nAnd that's a line\\nAnd there's a line too\\n"|
             end
           },
         )
@@ -464,7 +464,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
               }
             ]
           ]
-          actual = [
+          actual   = [
             [
               :h2,
               [:span, [:text, "Goodbye world"]],
@@ -489,45 +489,45 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(actual).to eq(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|[[:h2, [:span, [:text, "Goodbye world"]], { id: "hero", class: "header", data: { "sticky" => false, :role => "deprecated", :person => #<SuperDiff::Test::Person name: "Doc", age: 60> } }], :br]|
+              plain    %|Expected |
+              actual   %|[[:h2, [:span, [:text, "Goodbye world"]], { id: "hero", class: "header", data: { "sticky" => false, :role => "deprecated", :person => #<SuperDiff::Test::Person name: "Doc", age: 60> } }], :br]|
             end
 
             line do
-              plain "   to eq "
-              alpha %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
+              plain    %|   to eq |
+              expected %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
             end
           },
           diff: proc {
-            plain_line %|  [|
-            plain_line %|    [|
-            alpha_line %|-     :h1,|
-            beta_line  %|+     :h2,|
-            plain_line %|      [|
-            plain_line %|        :span,|
-            plain_line %|        [|
-            plain_line %|          :text,|
-            alpha_line %|-         "Hello world"|
-            beta_line  %|+         "Goodbye world"|
-            plain_line %|        ]|
-            plain_line %|      ],|
-            plain_line %|      {|
-            beta_line  %|+       id: "hero",|
-            plain_line %|        class: "header",|
-            plain_line %|        data: {|
-            alpha_line %|-         "sticky" => true,|
-            beta_line  %|+         "sticky" => false,|
-            beta_line  %|+         role: "deprecated",|
-            plain_line %|          person: #<SuperDiff::Test::Person {|
-            alpha_line %|-           name: "Marty",|
-            beta_line  %|+           name: "Doc",|
-            plain_line %|            age: 60|
-            plain_line %|          }>|
-            plain_line %|        }|
-            plain_line %|      }|
-            plain_line %|    ],|
-            beta_line  %|+   :br|
-            plain_line %|  ]|
+            plain_line    %|  [|
+            plain_line    %|    [|
+            expected_line %|-     :h1,|
+            actual_line   %|+     :h2,|
+            plain_line    %|      [|
+            plain_line    %|        :span,|
+            plain_line    %|        [|
+            plain_line    %|          :text,|
+            expected_line %|-         "Hello world"|
+            actual_line   %|+         "Goodbye world"|
+            plain_line    %|        ]|
+            plain_line    %|      ],|
+            plain_line    %|      {|
+            actual_line   %|+       id: "hero",|
+            plain_line    %|        class: "header",|
+            plain_line    %|        data: {|
+            expected_line %|-         "sticky" => true,|
+            actual_line   %|+         "sticky" => false,|
+            actual_line   %|+         role: "deprecated",|
+            plain_line    %|          person: #<SuperDiff::Test::Person {|
+            expected_line %|-           name: "Marty",|
+            actual_line   %|+           name: "Doc",|
+            plain_line    %|            age: 60|
+            plain_line    %|          }>|
+            plain_line    %|        }|
+            plain_line    %|      }|
+            plain_line    %|    ],|
+            actual_line   %|+   :br|
+            plain_line    %|  ]|
           },
         )
 
@@ -563,13 +563,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain " Expected "
-              beta %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
+              plain    %| Expected |
+              actual   %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
             end
 
             line do
-              plain "not to eq "
-              alpha %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
+              plain    %|not to eq |
+              expected %|[[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true, :person => #<SuperDiff::Test::Person name: "Marty", age: 60> } }]]|
             end
           },
         )
@@ -604,7 +604,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
               { name: "Chevy 4x4" }
             ]
           }
-          actual = {
+          actual   = {
             customer: {
               person: SuperDiff::Test::Person.new(name: "Marty McFly, Jr.", age: 17),
               shipping_address: {
@@ -632,47 +632,47 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           snippet: %|expect(actual).to eq(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly, Jr.", age: 17>, shipping_address: { line_1: "456 Ponderosa Ct.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Mattel Hoverboard" }] }|
+              plain    %|Expected |
+              actual   %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly, Jr.", age: 17>, shipping_address: { line_1: "456 Ponderosa Ct.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Mattel Hoverboard" }] }|
             end
 
             line do
-              plain "   to eq "
-              alpha %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
+              plain    %|   to eq |
+              expected %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            plain_line %|    customer: {|
-            plain_line %|      person: #<SuperDiff::Test::Person {|
-            alpha_line %|-       name: "Marty McFly",|
-            beta_line  %|+       name: "Marty McFly, Jr.",|
-            plain_line %|        age: 17|
-            plain_line %|      }>,|
-            plain_line %|      shipping_address: {|
-            alpha_line %|-       line_1: "123 Main St.",|
-            beta_line  %|+       line_1: "456 Ponderosa Ct.",|
-            plain_line %|        city: "Hill Valley",|
-            plain_line %|        state: "CA",|
-            plain_line %|        zip: "90382"|
-            plain_line %|      }|
-            plain_line %|    },|
-            plain_line %|    items: [|
-            plain_line %|      {|
-            plain_line %|        name: "Fender Stratocaster",|
-            plain_line %|        cost: 100000,|
-            plain_line %|        options: [|
-            plain_line %|          "red",|
-            plain_line %|          "blue",|
-            plain_line %|          "green"|
-            plain_line %|        ]|
-            plain_line %|      },|
-            plain_line %|      {|
-            alpha_line %|-       name: "Chevy 4x4"|
-            beta_line  %|+       name: "Mattel Hoverboard"|
-            plain_line %|      }|
-            plain_line %|    ]|
-            plain_line %|  }|
+            plain_line    %|  {|
+            plain_line    %|    customer: {|
+            plain_line    %|      person: #<SuperDiff::Test::Person {|
+            expected_line %|-       name: "Marty McFly",|
+            actual_line   %|+       name: "Marty McFly, Jr.",|
+            plain_line    %|        age: 17|
+            plain_line    %|      }>,|
+            plain_line    %|      shipping_address: {|
+            expected_line %|-       line_1: "123 Main St.",|
+            actual_line   %|+       line_1: "456 Ponderosa Ct.",|
+            plain_line    %|        city: "Hill Valley",|
+            plain_line    %|        state: "CA",|
+            plain_line    %|        zip: "90382"|
+            plain_line    %|      }|
+            plain_line    %|    },|
+            plain_line    %|    items: [|
+            plain_line    %|      {|
+            plain_line    %|        name: "Fender Stratocaster",|
+            plain_line    %|        cost: 100000,|
+            plain_line    %|        options: [|
+            plain_line    %|          "red",|
+            plain_line    %|          "blue",|
+            plain_line    %|          "green"|
+            plain_line    %|        ]|
+            plain_line    %|      },|
+            plain_line    %|      {|
+            expected_line %|-       name: "Chevy 4x4"|
+            actual_line   %|+       name: "Mattel Hoverboard"|
+            plain_line    %|      }|
+            plain_line    %|    ]|
+            plain_line    %|  }|
           },
         )
 
@@ -714,13 +714,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain " Expected "
-              beta %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
+              plain    %| Expected |
+              actual   %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
             end
 
             line do
-              plain "not to eq "
-              alpha %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
+              plain    %|not to eq |
+              expected %|{ customer: { person: #<SuperDiff::Test::Person name: "Marty McFly", age: 17>, shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] }|
             end
           },
         )
@@ -740,7 +740,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             name: "Marty",
             age: 31,
           )
-          actual = SuperDiff::Test::Customer.new(
+          actual   = SuperDiff::Test::Customer.new(
             name: "Doc",
             shipping_address: :some_shipping_address,
             phone: "1234567890",
@@ -755,13 +755,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|#<SuperDiff::Test::Customer name: "Doc", shipping_address: :some_shipping_address, phone: "1234567890">|
+              plain    %|Expected |
+              actual   %|#<SuperDiff::Test::Customer name: "Doc", shipping_address: :some_shipping_address, phone: "1234567890">|
             end
 
             line do
-              plain "   to eq "
-              alpha %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
+              plain    %|   to eq |
+              expected %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
             end
           },
         )
@@ -789,13 +789,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain " Expected "
-              beta %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
+              plain    %| Expected |
+              actual   %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
             end
 
             line do
-              plain "not to eq "
-              alpha %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
+              plain    %|not to eq |
+              expected %|#<SuperDiff::Test::Person name: "Marty", age: 31>|
             end
           },
         )
@@ -815,7 +815,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             name: "camera",
             quantity: 3,
           )
-          actual = SuperDiff::Test::Player.new(
+          actual   = SuperDiff::Test::Player.new(
             handle: "mcmire",
             character: "Jon",
             inventory: ["sword"],
@@ -835,13 +835,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             if SuperDiff::Test.jruby?
             else
               line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Player @handle="mcmire", @character="Jon", @inventory=["sword"], @shields=11.4, @health=4, @ultimate=true>|
+                plain    %|Expected |
+                actual   %|#<SuperDiff::Test::Player @handle="mcmire", @character="Jon", @inventory=["sword"], @shields=11.4, @health=4, @ultimate=true>|
               end
 
               line do
-                plain "   to eq "
-                alpha %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
+                plain    %|   to eq |
+                expected %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
               end
             end
           },
@@ -873,13 +873,13 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             if SuperDiff::Test.jruby?
             else
               line do
-                plain " Expected "
-                beta %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
+                plain    %| Expected |
+                actual   %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
               end
 
               line do
-                plain "not to eq "
-                alpha %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
+                plain    %|not to eq |
+                expected %|#<SuperDiff::Test::Item @name="camera", @quantity=3>|
               end
             end
           },
@@ -898,7 +898,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = { foo: nil }
-          actual = { foo: [] }
+          actual   = { foo: [] }
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -909,18 +909,18 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{ foo: [] }|
-              plain " to eq "
-              alpha %|{ foo: nil }|
-              plain "."
+              plain    %|Expected |
+              actual   %|{ foo: [] }|
+              plain    %| to eq |
+              expected %|{ foo: nil }|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            alpha_line %|-   foo: nil|
-            beta_line  %|+   foo: []|
-            plain_line %|  }|
+            plain_line    %|  {|
+            expected_line %|-   foo: nil|
+            actual_line   %|+   foo: []|
+            plain_line    %|  }|
           }
         )
 
@@ -936,7 +936,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = { foo: nil }
-          actual = { foo: {} }
+          actual   = { foo: {} }
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -947,18 +947,18 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{ foo: {} }|
-              plain " to eq "
-              alpha %|{ foo: nil }|
-              plain "."
+              plain    %|Expected |
+              actual   %|{ foo: {} }|
+              plain    %| to eq |
+              expected %|{ foo: nil }|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            alpha_line %|-   foo: nil|
-            beta_line  %|+   foo: {}|
-            plain_line %|  }|
+            plain_line    %|  {|
+            expected_line %|-   foo: nil|
+            actual_line   %|+   foo: {}|
+            plain_line    %|  }|
           }
         )
 
@@ -974,7 +974,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = { foo: nil }
-          actual = { foo: SuperDiff::Test::EmptyClass.new }
+          actual   = { foo: SuperDiff::Test::EmptyClass.new }
           expect(actual).to eq(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -985,18 +985,18 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{ foo: #<SuperDiff::Test::EmptyClass> }|
-              plain " to eq "
-              alpha %|{ foo: nil }|
-              plain "."
+              plain    %|Expected |
+              actual   %|{ foo: #<SuperDiff::Test::EmptyClass> }|
+              plain    %| to eq |
+              expected %|{ foo: nil }|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            alpha_line %|-   foo: nil|
-            beta_line  %|+   foo: #<SuperDiff::Test::EmptyClass>|
-            plain_line %|  }|
+            plain_line    %|  {|
+            expected_line %|-   foo: nil|
+            actual_line   %|+   foo: #<SuperDiff::Test::EmptyClass>|
+            plain_line    %|  }|
           }
         )
 

--- a/spec/integration/rspec/have_attributes_matcher_spec.rb
+++ b/spec/integration/rspec/have_attributes_matcher_spec.rb
@@ -1,14 +1,14 @@
 require "spec_helper"
 
 RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integration do
-  context "when the actual value is an object" do
+  context "when the actual   value is an object" do
     context "with a small set of attributes" do
-      context "when all of the names are methods on the actual object" do
+      context "when all of the names are methods on the actual   object" do
         it "produces the correct output when used in the positive" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
               expected = { name: "b" }
-              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              actual   = SuperDiff::Test::Person.new(name: "a", age: 9)
               expect(actual).to have_attributes(expected)
             TEST
             program = make_plain_test_program(
@@ -21,20 +21,20 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               snippet: %|expect(actual).to have_attributes(expected)|,
               expectation: proc {
                 line do
-                  plain "Expected "
-                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                  plain " to have attributes "
-                  alpha %|(name: "b")|
-                  plain "."
+                  plain    %|Expected |
+                  actual   %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain    %| to have attributes |
+                  expected %|(name: "b")|
+                  plain    %|.|
                 end
               },
               diff: proc {
-                plain_line %|  #<SuperDiff::Test::Person {|
-                # alpha_line %|-   name: "b",|  # FIXME
-                alpha_line %|-   name: "b"|
-                beta_line  %|+   name: "a",|
-                plain_line %|    age: 9|
-                plain_line %|  }>|
+                plain_line    %|  #<SuperDiff::Test::Person {|
+                # expected_line %|-   name: "b",|  # FIXME
+                expected_line %|-   name: "b"|
+                actual_line   %|+   name: "a",|
+                plain_line    %|    age: 9|
+                plain_line    %|  }>|
               },
             )
 
@@ -48,7 +48,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
               expected = { name: "a" }
-              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              actual   = SuperDiff::Test::Person.new(name: "a", age: 9)
               expect(actual).not_to have_attributes(expected)
             TEST
             program = make_plain_test_program(
@@ -61,11 +61,11 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               snippet: %|expect(actual).not_to have_attributes(expected)|,
               expectation: proc {
                 line do
-                  plain "Expected "
-                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                  plain " not to have attributes "
-                  alpha %|(name: "a")|
-                  plain "."
+                  plain    %|Expected |
+                  actual   %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain    %| not to have attributes |
+                  expected %|(name: "a")|
+                  plain    %|.|
                 end
               },
             )
@@ -77,12 +77,12 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
         end
       end
 
-      context "when some of the names are not methods on the actual object" do
+      context "when some of the names are not methods on the actual   object" do
         it "produces the correct output" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
               expected = { name: "b", foo: "bar" }
-              actual = SuperDiff::Test::Person.new(name: "a", age: 9)
+              actual   = SuperDiff::Test::Person.new(name: "a", age: 9)
               expect(actual).to have_attributes(expected)
             TEST
             program = make_plain_test_program(
@@ -95,23 +95,23 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               snippet: %|expect(actual).to have_attributes(expected)|,
               expectation: proc {
                 line do
-                  plain "Expected "
-                  beta %|#<SuperDiff::Test::Person name: "a", age: 9>|
-                  plain " to respond to "
-                  alpha %|:foo|
-                  plain " with "
-                  alpha %|0|
-                  plain " arguments."
+                  plain    %|Expected |
+                  actual   %|#<SuperDiff::Test::Person name: "a", age: 9>|
+                  plain    %| to respond to |
+                  expected %|:foo|
+                  plain    %| with |
+                  expected %|0|
+                  plain    %| arguments.|
                 end
               },
               diff: proc {
-                plain_line %|  #<SuperDiff::Test::Person {|
-                plain_line %|    name: "a",|
-                # plain_line %|    age: 9,|  # FIXME
-                plain_line %|    age: 9|
-                # alpha_line %|-   foo: "bar",|  # FIXME
-                alpha_line %|-   foo: "bar"|
-                plain_line %|  }>|
+                plain_line    %|  #<SuperDiff::Test::Person {|
+                plain_line    %|    name: "a",|
+                # plain_line    %|    age: 9,|  # FIXME
+                plain_line    %|    age: 9|
+                # expected_line %|-   foo: "bar",|  # FIXME
+                expected_line %|-   foo: "bar"|
+                plain_line    %|  }>|
               },
             )
 
@@ -124,7 +124,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
     end
 
     context "with a large set of attributes" do
-      context "when all of the names are methods on the actual object" do
+      context "when all of the names are methods on the actual   object" do
         it "produces the correct output when used in the positive" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -134,7 +134,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
                 state: "CA",
                 zip: "91234"
               }
-              actual = SuperDiff::Test::ShippingAddress.new(
+              actual   = SuperDiff::Test::ShippingAddress.new(
                 line_1: "456 Ponderosa Ct.",
                 line_2: nil,
                 city: "Hill Valley",
@@ -153,27 +153,27 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               snippet: %|expect(actual).to have_attributes(expected)|,
               expectation: proc {
                 line do
-                  plain "          Expected "
-                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
+                  plain    %|          Expected |
+                  actual   %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
                 end
 
                 line do
-                  plain "to have attributes "
-                  alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
+                  plain    %|to have attributes |
+                  expected %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
                 end
               },
               diff: proc {
-                plain_line %|  #<SuperDiff::Test::ShippingAddress {|
-                alpha_line %|-   line_1: "123 Main St.",|
-                beta_line  %|+   line_1: "456 Ponderosa Ct.",|
-                plain_line %|    line_2: nil,|
-                alpha_line %|-   city: "Oakland",|
-                beta_line  %|+   city: "Hill Valley",|
-                plain_line %|    state: "CA",|
-                # alpha_line %|-   zip: "91234",|  # FIXME
-                alpha_line %|-   zip: "91234"|
-                beta_line  %|+   zip: "90382"|
-                plain_line %|  }>|
+                plain_line    %|  #<SuperDiff::Test::ShippingAddress {|
+                expected_line %|-   line_1: "123 Main St.",|
+                actual_line   %|+   line_1: "456 Ponderosa Ct.",|
+                plain_line    %|    line_2: nil,|
+                expected_line %|-   city: "Oakland",|
+                actual_line   %|+   city: "Hill Valley",|
+                plain_line    %|    state: "CA",|
+                # expected_line %|-   zip: "91234",|  # FIXME
+                expected_line %|-   zip: "91234"|
+                actual_line   %|+   zip: "90382"|
+                plain_line    %|  }>|
               },
             )
 
@@ -192,7 +192,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
                 state: "CA",
                 zip: "91234"
               }
-              actual = SuperDiff::Test::ShippingAddress.new(
+              actual   = SuperDiff::Test::ShippingAddress.new(
                 line_1: "123 Main St.",
                 line_2: nil,
                 city: "Oakland",
@@ -212,13 +212,13 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               newline_before_expectation: true,
               expectation: proc {
                 line do
-                  plain "              Expected "
-                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
+                  plain    %|              Expected |
+                  actual   %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
                 end
 
                 line do
-                  plain "not to have attributes "
-                  alpha %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
+                  plain    %|not to have attributes |
+                  expected %|(line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")|
                 end
               },
             )
@@ -230,7 +230,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
         end
       end
 
-      context "when some of the names are not methods on the actual object" do
+      context "when some of the names are not methods on the actual   object" do
         it "produces the correct output" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -242,7 +242,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
                 foo: "bar",
                 baz: "qux"
               }
-              actual = SuperDiff::Test::ShippingAddress.new(
+              actual   = SuperDiff::Test::ShippingAddress.new(
                 line_1: "456 Ponderosa Ct.",
                 line_2: nil,
                 city: "Hill Valley",
@@ -261,32 +261,32 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               snippet: %|expect(actual).to have_attributes(expected)|,
               expectation: proc {
                 line do
-                  plain "     Expected "
-                  beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
+                  plain    %|     Expected |
+                  actual   %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
                 end
 
                 line do
-                  plain "to respond to "
-                  alpha %|:foo|
-                  plain " and "
-                  alpha %|:baz|
-                  plain " with "
-                  alpha %|0|
-                  plain " arguments"
+                  plain    %|to respond to |
+                  expected %|:foo|
+                  plain    %| and |
+                  expected %|:baz|
+                  plain    %| with |
+                  expected %|0|
+                  plain    %| arguments|
                 end
               },
               diff: proc {
-                plain_line %|  #<SuperDiff::Test::ShippingAddress {|
-                plain_line %|    line_1: "456 Ponderosa Ct.",|
-                plain_line %|    line_2: nil,|
-                plain_line %|    city: "Hill Valley",|
-                plain_line %|    state: "CA",|
-                # plain_line %|    zip: "90382",|  # FIXME
-                plain_line %|    zip: "90382"|
-                # alpha_line %|-   foo: "bar",|  # FIXME
-                alpha_line %|-   foo: "bar"|
-                alpha_line %|-   baz: "qux"|
-                plain_line %|  }>|
+                plain_line    %|  #<SuperDiff::Test::ShippingAddress {|
+                plain_line    %|    line_1: "456 Ponderosa Ct.",|
+                plain_line    %|    line_2: nil,|
+                plain_line    %|    city: "Hill Valley",|
+                plain_line    %|    state: "CA",|
+                # plain_line    %|    zip: "90382",|  # FIXME
+                plain_line    %|    zip: "90382"|
+                # expected_line %|-   foo: "bar",|  # FIXME
+                expected_line %|-   foo: "bar"|
+                expected_line %|-   baz: "qux"|
+                plain_line    %|  }>|
               },
             )
 
@@ -299,12 +299,12 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
     end
   end
 
-  context "when the actual value is actually a hash instead of an object" do
+  context "when the actual   value is actually a hash instead of an object" do
     it "displays the diff as if we were comparing hashes" do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = { name: "Elliot", age: 32 }
-          actual = {}
+          actual   = {}
           expect(actual).to have_attributes(expected)
         TEST
 
@@ -315,22 +315,22 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
           snippet: %|expect(actual).to have_attributes(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{}|
-              plain " to respond to "
-              alpha %|:name|
-              plain " and "
-              alpha %|:age|
-              plain " with "
-              alpha %|0|
-              plain " arguments."
+              plain    %|Expected |
+              actual   %|{}|
+              plain    %| to respond to |
+              expected %|:name|
+              plain    %| and |
+              expected %|:age|
+              plain    %| with |
+              expected %|0|
+              plain    %| arguments.|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            alpha_line %|-   name: "Elliot",|
-            alpha_line %|-   age: 32|
-            plain_line %|  }|
+            plain_line    %|  {|
+            expected_line %|-   name: "Elliot",|
+            expected_line %|-   age: 32|
+            plain_line    %|  }|
           },
         )
 
@@ -359,7 +359,7 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               created_at: a_value_within(1).of(Time.utc(2020, 4, 9))
             }
 
-            actual = {}
+            actual   = {}
 
             expect(actual).to have_attributes(expected)
           TEST
@@ -374,45 +374,45 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
             snippet: %|expect(actual).to have_attributes(expected)|,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|{}|
+                plain    %|     Expected |
+                actual   %|{}|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:name|
-                plain ", "
-                alpha %|:shipping_address|
-                plain ", "
-                alpha %|:order_ids|
-                plain ", "
-                alpha %|:data|
-                plain " and "
-                alpha %|:created_at|
-                plain " with "
-                alpha %|0|
-                plain " arguments"
+                plain    %|to respond to |
+                expected %|:name|
+                plain    %|, |
+                expected %|:shipping_address|
+                plain    %|, |
+                expected %|:order_ids|
+                plain    %|, |
+                expected %|:data|
+                plain    %| and |
+                expected %|:created_at|
+                plain    %| with |
+                expected %|0|
+                plain    %| arguments|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              alpha_line %|-   name: "Elliot",|
-              alpha_line %|-   shipping_address: #<an object having attributes (|
-              alpha_line %|-     line_1: #<a kind of String>,|
-              alpha_line %|-     line_2: nil,|
-              alpha_line %|-     city: #<an instance of String>,|
-              alpha_line %|-     state: "CA",|
-              alpha_line %|-     zip: "91234"|
-              alpha_line %|-   )>,|
-              alpha_line %|-   order_ids: #<a collection including (|
-              alpha_line %|-     1,|
-              alpha_line %|-     2|
-              alpha_line %|-   )>,|
-              alpha_line %|-   data: #<a hash including (|
-              alpha_line %|-     active: true|
-              alpha_line %|-   )>,|
-              alpha_line %|-   created_at: #<a value within 1 of 2020-04-09 00:00:00.000 UTC +00:00 (Time)>|
-              plain_line %|  }|
+              plain_line    %|  {|
+              expected_line %|-   name: "Elliot",|
+              expected_line %|-   shipping_address: #<an object having attributes (|
+              expected_line %|-     line_1: #<a kind of String>,|
+              expected_line %|-     line_2: nil,|
+              expected_line %|-     city: #<an instance of String>,|
+              expected_line %|-     state: "CA",|
+              expected_line %|-     zip: "91234"|
+              expected_line %|-   )>,|
+              expected_line %|-   order_ids: #<a collection including (|
+              expected_line %|-     1,|
+              expected_line %|-     2|
+              expected_line %|-   )>,|
+              expected_line %|-   data: #<a hash including (|
+              expected_line %|-     active: true|
+              expected_line %|-   )>,|
+              expected_line %|-   created_at: #<a value within 1 of 2020-04-09 00:00:00.000 UTC +00:00 (Time)>|
+              plain_line    %|  }|
             },
           )
 

--- a/spec/integration/rspec/have_predicate_matcher_spec.rb
+++ b/spec/integration/rspec/have_predicate_matcher_spec.rb
@@ -16,11 +16,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             snippet: snippet,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|:words|
-                plain " to respond to "
-                alpha %|has_power?|
-                plain "."
+                plain    %|Expected |
+                actual   %|:words|
+                plain    %| to respond to |
+                expected %|has_power?|
+                plain    %|.|
               end
             },
           )
@@ -32,7 +32,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
       end
     end
 
-    context "when the inspected version of the actual value is long" do
+    context "when the inspected version of the actual   value is long" do
       it "produces the correct failure message" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -50,13 +50,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                plain    %|     Expected |
+                actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
               end
 
               line do
-                plain "to respond to "
-                alpha %|has_mapping?|
+                plain    %|to respond to |
+                expected %|has_mapping?|
               end
             },
           )
@@ -71,7 +71,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
 
   context "when the predicate method exists on the object" do
     context "but is private" do
-      context "when the inspected version of the actual value is short" do
+      context "when the inspected version of the actual   value is short" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -91,11 +91,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
               snippet: %|expect(Robot.new).to have_arms|,
               expectation: proc {
                 line do
-                  plain "Expected "
-                  beta %|#<Robot>|
-                  plain " to have a public method "
-                  alpha %|has_arms?|
-                  plain "."
+                  plain    %|Expected |
+                  actual   %|#<Robot>|
+                  plain    %| to have a public method |
+                  expected %|has_arms?|
+                  plain    %|.|
                 end
               },
             )
@@ -108,7 +108,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
         end
       end
 
-      context "when the inspected version of the actual value is long" do
+      context "when the inspected version of the actual   value is long" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -131,13 +131,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
               newline_before_expectation: true,
               expectation: proc {
                 line do
-                  plain "               Expected "
-                  beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                  plain    %|               Expected |
+                  actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
                 end
 
                 line do
-                  plain "to have a public method "
-                  alpha %|has_mapping?|
+                  plain    %|to have a public method |
+                  expected %|has_mapping?|
                 end
               },
             )
@@ -154,7 +154,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
     context "and is public" do
       context "and returns false" do
         context "and takes arguments" do
-          context "when the inspected version of the actual value is short" do
+          context "when the inspected version of the actual   value is short" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -174,11 +174,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   snippet: %|expect(Drink.new).to have_ingredients(:vodka)|,
                   expectation: proc {
                     line do
-                      plain "Expected "
-                      beta %|#<Drink>|
-                      plain " to return a truthy result for "
-                      alpha %|has_ingredients?(:vodka)|
-                      plain "."
+                      plain    %|Expected |
+                      actual   %|#<Drink>|
+                      plain    %| to return a truthy result for |
+                      expected %|has_ingredients?(:vodka)|
+                      plain    %|.|
                     end
                   },
                 )
@@ -191,7 +191,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             end
           end
 
-          context "when the inspected version of the actual value is long" do
+          context "when the inspected version of the actual   value is long" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -214,13 +214,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "                     Expected "
-                      beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                      plain    %|                     Expected |
+                      actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
                     end
 
                     line do
-                      plain "to return a truthy result for "
-                      alpha %|has_contents?("keys", "upon", "keys")|
+                      plain    %|to return a truthy result for |
+                      expected %|has_contents?("keys", "upon", "keys")|
                     end
                   },
                 )
@@ -235,7 +235,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
         end
 
         context "and takes no arguments" do
-          context "when the inspected version of the actual value is short" do
+          context "when the inspected version of the actual   value is short" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -255,11 +255,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   snippet: %|expect(Robot.new).to have_arms|,
                   expectation: proc {
                     line do
-                      plain "Expected "
-                      beta %|#<Robot>|
-                      plain " to return a truthy result for "
-                      alpha %|has_arms?|
-                      plain "."
+                      plain    %|Expected |
+                      actual   %|#<Robot>|
+                      plain    %| to return a truthy result for |
+                      expected %|has_arms?|
+                      plain    %|.|
                     end
                   },
                 )
@@ -272,7 +272,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             end
           end
 
-          context "when the inspected version of the actual value is long" do
+          context "when the inspected version of the actual   value is long" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -295,13 +295,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "                     Expected "
-                      beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                      plain    %|                     Expected |
+                      actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
                     end
 
                     line do
-                      plain "to return a truthy result for "
-                      alpha %|has_mapping?|
+                      plain    %|to return a truthy result for |
+                      expected %|has_mapping?|
                     end
                   },
                 )
@@ -318,7 +318,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
 
       context "and returns true" do
         context "and takes arguments" do
-          context "when the inspected version of the actual value is short" do
+          context "when the inspected version of the actual   value is short" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -338,11 +338,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   snippet: %|expect(Drink.new).not_to have_ingredients(:vodka)|,
                   expectation: proc {
                     line do
-                      plain "Expected "
-                      beta %|#<Drink>|
-                      plain " not to return a truthy result for "
-                      alpha %|has_ingredients?(:vodka)|
-                      plain "."
+                      plain    %|Expected |
+                      actual   %|#<Drink>|
+                      plain    %| not to return a truthy result for |
+                      expected %|has_ingredients?(:vodka)|
+                      plain    %|.|
                     end
                   },
                 )
@@ -355,7 +355,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             end
           end
 
-          context "when the inspected version of the actual value is long" do
+          context "when the inspected version of the actual   value is long" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -378,13 +378,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "                         Expected "
-                      beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                      plain    %|                         Expected |
+                      actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
                     end
 
                     line do
-                      plain "not to return a truthy result for "
-                      alpha %|has_contents?("keys", "upon", "keys")|
+                      plain    %|not to return a truthy result for |
+                      expected %|has_contents?("keys", "upon", "keys")|
                     end
                   },
                 )
@@ -399,7 +399,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
         end
 
         context "and takes no arguments" do
-          context "when the inspected version of the actual value is short" do
+          context "when the inspected version of the actual   value is short" do
             it "produces the correct failure message when used in the negative" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -419,11 +419,11 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   snippet: %|expect(Robot.new).not_to have_arms|,
                   expectation: proc {
                     line do
-                      plain "Expected "
-                      beta %|#<Robot>|
-                      plain " not to return a truthy result for "
-                      alpha %|has_arms?|
-                      plain "."
+                      plain    %|Expected |
+                      actual   %|#<Robot>|
+                      plain    %| not to return a truthy result for |
+                      expected %|has_arms?|
+                      plain    %|.|
                     end
                   },
                 )
@@ -436,7 +436,7 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
             end
           end
 
-          context "when the inspected version of the actual value is long" do
+          context "when the inspected version of the actual   value is long" do
             it "produces the correct failure message when used in the negative" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
@@ -459,13 +459,13 @@ RSpec.describe "Integration with RSpec's #have_<predicate> matcher", type: :inte
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "                         Expected "
-                      beta %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
+                      plain    %|                         Expected |
+                      actual   %|{ a: "lot", of: "keys", and: "things", like: "that", lets: "add", more: "keys" }|
                     end
 
                     line do
-                      plain "not to return a truthy result for "
-                      alpha %|has_mapping?|
+                      plain    %|not to return a truthy result for |
+                      expected %|has_mapping?|
                     end
                   },
                 )

--- a/spec/integration/rspec/include_matcher_spec.rb
+++ b/spec/integration/rspec/include_matcher_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = ["Marty", "Einie"]
-            actual = ["Marty", "Jennifer", "Doc"]
+            actual   = ["Marty", "Jennifer", "Doc"]
             expect(actual).to include(*expected)
           TEST
           program = make_plain_test_program(
@@ -20,21 +20,21 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(actual).to include(*expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["Marty", "Jennifer", "Doc"]|
-                plain " to include "
-                alpha %|"Einie"|
-                plain "."
+                plain    %|Expected |
+                actual   %|["Marty", "Jennifer", "Doc"]|
+                plain    %| to include |
+                expected %|"Einie"|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty",|
-              plain_line %|    "Jennifer",|
-              # plain_line %|    "Doc",|   # FIXME
-              plain_line %|    "Doc"|
-              alpha_line %|-   "Einie"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty",|
+              plain_line    %|    "Jennifer",|
+              # plain_line    %|    "Doc",|   # FIXME
+              plain_line    %|    "Doc"|
+              expected_line %|-   "Einie"|
+              plain_line    %|  ]|
             },
           )
 
@@ -60,11 +60,11 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(values).not_to include(*values)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["Marty", "Einie"]|
-                plain " not to include "
-                alpha %|"Marty" and "Einie"|
-                plain "."
+                plain    %|Expected |
+                actual   %|["Marty", "Einie"]|
+                plain    %| not to include |
+                expected %|"Marty" and "Einie"|
+                plain    %|.|
               end
             },
           )
@@ -88,7 +88,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
               "George McFly",
               "Lorraine McFly"
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -106,25 +106,25 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(actual).to include(*expected)|,
             expectation: proc {
               line do
-                plain "  Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|  Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "to include "
-                alpha %|"Biff Tannen" and "George McFly"|
+                plain    %|to include |
+                expected %|"Biff Tannen" and "George McFly"|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty McFly",|
-              plain_line %|    "Doc Brown",|
-              plain_line %|    "Einie",|
-              # plain_line %|    "Lorraine McFly",|   # FIXME
-              plain_line %|    "Lorraine McFly"|
-              alpha_line %|-   "Biff Tannen",|
-              alpha_line %|-   "George McFly"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty McFly",|
+              plain_line    %|    "Doc Brown",|
+              plain_line    %|    "Einie",|
+              # plain_line    %|    "Lorraine McFly",|   # FIXME
+              plain_line    %|    "Lorraine McFly"|
+              expected_line %|-   "Biff Tannen",|
+              expected_line %|-   "George McFly"|
+              plain_line    %|  ]|
             },
           )
 
@@ -143,7 +143,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
               "Einie",
               "Lorraine McFly"
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -164,13 +164,13 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "      Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Biff Tannen", "George McFly", "Lorraine McFly"]|
+                plain    %|      Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Biff Tannen", "George McFly", "Lorraine McFly"]|
               end
 
               line do
-                plain "not to include "
-                alpha %|"Marty McFly", "Doc Brown", "Einie", and "Lorraine McFly"|
+                plain    %|not to include |
+                expected %|"Marty McFly", "Doc Brown", "Einie", and "Lorraine McFly"|
               end
             },
           )
@@ -189,7 +189,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = { city: "Hill Valley", state: "CA" }
-            actual = { city: "Burbank", zip: "90210" }
+            actual   = { city: "Burbank", zip: "90210" }
             expect(actual).to include(expected)
           TEST
           program = make_plain_test_program(
@@ -202,22 +202,22 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(actual).to include(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ city: "Burbank", zip: "90210" }|
-                plain " to include "
-                alpha %|(city: "Hill Valley", state: "CA")|
-                plain "."
+                plain    %|Expected |
+                actual   %|{ city: "Burbank", zip: "90210" }|
+                plain    %| to include |
+                expected %|(city: "Hill Valley", state: "CA")|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              alpha_line %|-   city: "Hill Valley",|
-              beta_line  %|+   city: "Burbank",|
+              plain_line    %|  {|
+              expected_line %|-   city: "Hill Valley",|
+              actual_line   %|+   city: "Burbank",|
               # FIXME
-              # alpha_line %|-   state: "CA",|
-              alpha_line %|-   state: "CA"|
-              plain_line %|    zip: "90210"|
-              plain_line %|  }|
+              # expected_line %|-   state: "CA",|
+              expected_line %|-   state: "CA"|
+              plain_line    %|    zip: "90210"|
+              plain_line    %|  }|
             },
           )
 
@@ -231,7 +231,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = { city: "Burbank" }
-            actual = { city: "Burbank", zip: "90210" }
+            actual   = { city: "Burbank", zip: "90210" }
             expect(actual).not_to include(expected)
           TEST
           program = make_plain_test_program(
@@ -244,11 +244,11 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(actual).not_to include(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ city: "Burbank", zip: "90210" }|
-                plain " not to include "
-                alpha %|(city: "Burbank")|
-                plain "."
+                plain    %|Expected |
+                actual   %|{ city: "Burbank", zip: "90210" }|
+                plain    %| not to include |
+                expected %|(city: "Burbank")|
+                plain    %|.|
               end
             },
           )
@@ -268,7 +268,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
               city: "Hill Valley",
               zip: "90382"
             }
-            actual = {
+            actual   = {
               city: "Burbank",
               state: "CA",
               zip: "90210"
@@ -285,23 +285,23 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             snippet: %|expect(actual).to include(expected)|,
             expectation: proc {
               line do
-                plain "  Expected "
-                beta %|{ city: "Burbank", state: "CA", zip: "90210" }|
+                plain    %|  Expected |
+                actual   %|{ city: "Burbank", state: "CA", zip: "90210" }|
               end
 
               line do
-                plain "to include "
-                alpha %|(city: "Hill Valley", zip: "90382")|
+                plain    %|to include |
+                expected %|(city: "Hill Valley", zip: "90382")|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              alpha_line %|-   city: "Hill Valley",|
-              beta_line  %|+   city: "Burbank",|
-              plain_line %|    state: "CA",|
-              alpha_line %|-   zip: "90382"|
-              beta_line  %|+   zip: "90210"|
-              plain_line %|  }|
+              plain_line    %|  {|
+              expected_line %|-   city: "Hill Valley",|
+              actual_line   %|+   city: "Burbank",|
+              plain_line    %|    state: "CA",|
+              expected_line %|-   zip: "90382"|
+              actual_line   %|+   zip: "90210"|
+              plain_line    %|  }|
             },
           )
 
@@ -315,7 +315,7 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = { city: "Hill Valley", state: "CA" }
-            actual = { city: "Hill Valley", state: "CA", zip: "90210" }
+            actual   = { city: "Hill Valley", state: "CA", zip: "90210" }
             expect(actual).not_to include(expected)
           TEST
           program = make_plain_test_program(
@@ -329,13 +329,13 @@ RSpec.describe "Integration with RSpec's #include matcher", type: :integration d
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "      Expected "
-                beta %|{ city: "Hill Valley", state: "CA", zip: "90210" }|
+                plain    %|      Expected |
+                actual   %|{ city: "Hill Valley", state: "CA", zip: "90210" }|
               end
 
               line do
-                plain "not to include "
-                alpha %|(city: "Hill Valley", state: "CA")|
+                plain    %|not to include |
+                expected %|(city: "Hill Valley", state: "CA")|
               end
             },
           )

--- a/spec/integration/rspec/match_array_matcher_spec.rb
+++ b/spec/integration/rspec/match_array_matcher_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = ["Einie", "Marty"]
-          actual = ["Marty", "Jennifer", "Doc"]
+          actual   = ["Marty", "Jennifer", "Doc"]
           expect(actual).to match_array(expected)
         TEST
         program = make_plain_test_program(
@@ -19,22 +19,22 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
           snippet: %|expect(actual).to match_array(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|["Marty", "Jennifer", "Doc"]|
-              plain " to match array with "
-              alpha %|"Einie"|
-              plain " and "
-              alpha %|"Marty"|
-              plain "."
+              plain    %|Expected |
+              actual   %|["Marty", "Jennifer", "Doc"]|
+              plain    %| to match array with |
+              expected %|"Einie"|
+              plain    %| and |
+              expected %|"Marty"|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  [|
-            plain_line %|    "Marty",|
-            beta_line  %|+   "Jennifer",|
-            beta_line  %|+   "Doc",|
-            alpha_line %|-   "Einie"|
-            plain_line %|  ]|
+            plain_line    %|  [|
+            plain_line    %|    "Marty",|
+            actual_line   %|+   "Jennifer",|
+            actual_line   %|+   "Doc",|
+            expected_line %|-   "Einie"|
+            plain_line    %|  ]|
           },
         )
 
@@ -60,13 +60,13 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
           snippet: %|expect(values).not_to match_array(values)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|["Einie", "Marty"]|
-              plain " not to match array with "
-              alpha %|"Einie"|
-              plain " and "
-              alpha %|"Marty"|
-              plain "."
+              plain    %|Expected |
+              actual   %|["Einie", "Marty"]|
+              plain    %| not to match array with |
+              expected %|"Einie"|
+              plain    %| and |
+              expected %|"Marty"|
+              plain    %|.|
             end
           },
         )
@@ -90,7 +90,7 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               "George McFly",
               "Lorraine McFly"
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -108,32 +108,32 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
             snippet: %|expect(actual).to match_array(expected)|,
             expectation: proc {
               line do
-                plain "           Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|           Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "to match array with "
-                alpha %|"Doc Brown"|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|"George McFly"|
-                plain " and "
-                alpha %|"Lorraine McFly"|
+                plain    %|to match array with |
+                expected %|"Doc Brown"|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|"George McFly"|
+                plain    %| and |
+                expected %|"Lorraine McFly"|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty McFly",|
-              plain_line %|    "Doc Brown",|
-              plain_line %|    "Lorraine McFly",|
-              beta_line  %|+   "Einie",|
-              alpha_line %|-   "Biff Tannen",|
-              alpha_line %|-   "George McFly"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty McFly",|
+              plain_line    %|    "Doc Brown",|
+              plain_line    %|    "Lorraine McFly",|
+              actual_line   %|+   "Einie",|
+              expected_line %|-   "Biff Tannen",|
+              expected_line %|-   "George McFly"|
+              plain_line    %|  ]|
             },
           )
 
@@ -165,19 +165,19 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "               Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|               Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "not to match array with "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Doc Brown"|
-                plain ", "
-                alpha %|"Einie"|
-                plain " and "
-                alpha %|"Lorraine McFly"|
+                plain    %|not to match array with |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Doc Brown"|
+                plain    %|, |
+                expected %|"Einie"|
+                plain    %| and |
+                expected %|"Lorraine McFly"|
               end
             },
           )
@@ -200,7 +200,7 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               /Georg McFly/,
               /Lorrain McFly/
             ]
-            actual = [
+            actual   = [
               "Marty McFly",
               "Doc Brown",
               "Einie",
@@ -218,33 +218,33 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
             snippet: %|expect(actual).to match_array(expected)|,
             expectation: proc {
               line do
-                plain "           Expected "
-                beta %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
+                plain    %|           Expected |
+                actual   %|["Marty McFly", "Doc Brown", "Einie", "Lorraine McFly"]|
               end
 
               line do
-                plain "to match array with "
-                alpha %|/ Brown$/|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|/Georg McFly/|
-                plain " and "
-                alpha %|/Lorrain McFly/|
+                plain    %|to match array with |
+                expected %|/ Brown$/|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|/Georg McFly/|
+                plain    %| and |
+                expected %|/Lorrain McFly/|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "Marty McFly",|
-              plain_line %|    "Doc Brown",|
-              beta_line  %|+   "Einie",|
-              beta_line  %|+   "Lorraine McFly",|
-              alpha_line %|-   "Biff Tannen",|
-              alpha_line %|-   /Georg McFly/,|
-              alpha_line %|-   /Lorrain McFly/|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "Marty McFly",|
+              plain_line    %|    "Doc Brown",|
+              actual_line   %|+   "Einie",|
+              actual_line   %|+   "Lorraine McFly",|
+              expected_line %|-   "Biff Tannen",|
+              expected_line %|-   /Georg McFly/,|
+              expected_line %|-   /Lorrain McFly/|
+              plain_line    %|  ]|
             },
           )
 
@@ -277,23 +277,23 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "               Expected "
+                plain    %|               Expected |
                 # rubocop:disable Metrics/LineLength
-                beta %|[/ Brown$/, "Marty McFly", "Biff Tannen", /Georg McFly/, /Lorrain McFly/]|
+                actual   %|[/ Brown$/, "Marty McFly", "Biff Tannen", /Georg McFly/, /Lorrain McFly/]|
                 # rubocop:enable Metrics/LineLength
               end
 
               line do
-                plain "not to match array with "
-                alpha %|/ Brown$/|
-                plain ", "
-                alpha %|"Marty McFly"|
-                plain ", "
-                alpha %|"Biff Tannen"|
-                plain ", "
-                alpha %|/Georg McFly/|
-                plain " and "
-                alpha %|/Lorrain McFly/|
+                plain    %|not to match array with |
+                expected %|/ Brown$/|
+                plain    %|, |
+                expected %|"Marty McFly"|
+                plain    %|, |
+                expected %|"Biff Tannen"|
+                plain    %|, |
+                expected %|/Georg McFly/|
+                plain    %| and |
+                expected %|/Lorrain McFly/|
               end
             },
           )
@@ -314,7 +314,7 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
               a_collection_containing_exactly("zing"),
               an_object_having_attributes(baz: "qux"),
             ]
-            actual = [
+            actual   = [
               { foo: "bar" },
               double(baz: "qux"),
               { blargh: "riddle" }
@@ -331,34 +331,34 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
             snippet: %|expect(actual).to match_array(expected)|,
             expectation: proc {
               line do
-                plain "           Expected "
+                plain    %|           Expected |
                 # rubocop:disable Metrics/LineLength
-                beta %|[{ foo: "bar" }, #<Double (anonymous)>, { blargh: "riddle" }]|
+                actual   %|[{ foo: "bar" }, #<Double (anonymous)>, { blargh: "riddle" }]|
                 # rubocop:enable Metrics/LineLength
               end
 
               line do
-                plain "to match array with "
-                alpha %|#<a hash including (foo: "bar")>|
-                plain ", "
-                alpha %|#<a collection containing exactly ("zing")>|
-                plain " and "
-                alpha %|#<an object having attributes (baz: "qux")>|
+                plain    %|to match array with |
+                expected %|#<a hash including (foo: "bar")>|
+                plain    %|, |
+                expected %|#<a collection containing exactly ("zing")>|
+                plain    %| and |
+                expected %|#<an object having attributes (baz: "qux")>|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    {|
-              plain_line %|      foo: "bar"|
-              plain_line %|    },|
-              plain_line %|    #<Double (anonymous)>,|
-              beta_line  %|+   {|
-              beta_line  %|+     blargh: "riddle"|
-              beta_line  %|+   },|
-              alpha_line %|-   #<a collection containing exactly (|
-              alpha_line %|-     "zing"|
-              alpha_line %|-   )>|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    {|
+              plain_line    %|      foo: "bar"|
+              plain_line    %|    },|
+              plain_line    %|    #<Double (anonymous)>,|
+              actual_line   %|+   {|
+              actual_line   %|+     blargh: "riddle"|
+              actual_line   %|+   },|
+              expected_line %|-   #<a collection containing exactly (|
+              expected_line %|-     "zing"|
+              expected_line %|-   )>|
+              plain_line    %|  ]|
             },
           )
 
@@ -375,7 +375,7 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
           expected = "Einie"
-          actual = ["Marty", "Jennifer", "Doc"]
+          actual   = ["Marty", "Jennifer", "Doc"]
           expect(actual).to match_array(expected)
         TEST
         program = make_plain_test_program(
@@ -388,20 +388,20 @@ RSpec.describe "Integration with RSpec's #match_array matcher", type: :integrati
           snippet: %|expect(actual).to match_array(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|["Marty", "Jennifer", "Doc"]|
-              plain " to match array with "
-              alpha %|"Einie"|
-              plain "."
+              plain    %|Expected |
+              actual   %|["Marty", "Jennifer", "Doc"]|
+              plain    %| to match array with |
+              expected %|"Einie"|
+              plain    %|.|
             end
           },
           diff: proc {
-            plain_line %|  [|
-            beta_line  %|+   "Marty",|
-            beta_line  %|+   "Jennifer",|
-            beta_line  %|+   "Doc",|
-            alpha_line %|-   "Einie"|
-            plain_line %|  ]|
+            plain_line    %|  [|
+            actual_line   %|+   "Marty",|
+            actual_line   %|+   "Jennifer",|
+            actual_line   %|+   "Doc",|
+            expected_line %|-   "Einie"|
+            plain_line    %|  ]|
           },
         )
 

--- a/spec/integration/rspec/match_matcher_spec.rb
+++ b/spec/integration/rspec/match_matcher_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_hash_including(city: "Hill Valley")
-            actual = { city: "Burbank" }
+            actual   = { city: "Burbank" }
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -20,18 +20,18 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ city: "Burbank" }|
-                plain " to match "
-                alpha %|#<a hash including (city: "Hill Valley")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|{ city: "Burbank" }|
+                plain    %| to match |
+                expected %|#<a hash including (city: "Hill Valley")>|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              alpha_line %|-   city: "Hill Valley"|
-              beta_line  %|+   city: "Burbank"|
-              plain_line %|  }|
+              plain_line    %|  {|
+              expected_line %|-   city: "Hill Valley"|
+              actual_line   %|+   city: "Burbank"|
+              plain_line    %|  }|
             },
           )
 
@@ -45,7 +45,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_hash_including(city: "Burbank")
-            actual = { city: "Burbank" }
+            actual   = { city: "Burbank" }
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -58,11 +58,11 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).not_to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ city: "Burbank" }|
-                plain " not to match "
-                alpha %|#<a hash including (city: "Burbank")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|{ city: "Burbank" }|
+                plain    %| not to match |
+                expected %|#<a hash including (city: "Burbank")>|
+                plain    %|.|
               end
             },
           )
@@ -82,7 +82,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               city: "Hill Valley",
               zip: "90382"
             )
-            actual = {
+            actual   = {
               line_1: "123 Main St.",
               city: "Burbank",
               state: "CA",
@@ -100,24 +100,24 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
+                plain    %|Expected |
+                actual   %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
               end
 
               line do
-                plain "to match "
-                alpha %|#<a hash including (city: "Hill Valley", zip: "90382")>|
+                plain    %|to match |
+                expected %|#<a hash including (city: "Hill Valley", zip: "90382")>|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    line_1: "123 Main St.",|
-              alpha_line %|-   city: "Hill Valley",|
-              beta_line  %|+   city: "Burbank",|
-              plain_line %|    state: "CA",|
-              alpha_line %|-   zip: "90382"|
-              beta_line  %|+   zip: "90210"|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    line_1: "123 Main St.",|
+              expected_line %|-   city: "Hill Valley",|
+              actual_line   %|+   city: "Burbank",|
+              plain_line    %|    state: "CA",|
+              expected_line %|-   zip: "90382"|
+              actual_line   %|+   zip: "90210"|
+              plain_line    %|  }|
             },
           )
 
@@ -134,7 +134,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               city: "Burbank",
               zip: "90210"
             )
-            actual = {
+            actual   = {
               line_1: "123 Main St.",
               city: "Burbank",
               state: "CA",
@@ -153,13 +153,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
+                plain    %|    Expected |
+                actual   %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
               end
 
               line do
-                plain "not to match "
-                alpha %|#<a hash including (city: "Burbank", zip: "90210")>|
+                plain    %|not to match |
+                expected %|#<a hash including (city: "Burbank", zip: "90210")>|
               end
             },
           )
@@ -173,7 +173,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
   end
 
   context "when the expected value includes a hash-including-<something>" do
-    context "and the corresponding actual value is a hash" do
+    context "and the corresponding actual   value is a hash" do
       it "produces the correct failure message when used in the positive" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -184,7 +184,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
                 zip: "90382"
               )
             }
-            actual = {
+            actual   = {
               name: "Marty McFly",
               address: {
                 line_1: "123 Main St.",
@@ -205,27 +205,27 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "Marty McFly", address: { line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" } }|
+                plain    %|Expected |
+                actual   %|{ name: "Marty McFly", address: { line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" } }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "Marty McFly", address: #<a hash including (city: "Hill Valley", zip: "90382")> }|
+                plain    %|to match |
+                expected %|{ name: "Marty McFly", address: #<a hash including (city: "Hill Valley", zip: "90382")> }|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    name: "Marty McFly",|
-              plain_line %|    address: {|
-              plain_line %|      line_1: "123 Main St.",|
-              alpha_line %|-     city: "Hill Valley",|
-              beta_line  %|+     city: "Burbank",|
-              plain_line %|      state: "CA",|
-              alpha_line %|-     zip: "90382"|
-              beta_line  %|+     zip: "90210"|
-              plain_line %|    }|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    name: "Marty McFly",|
+              plain_line    %|    address: {|
+              plain_line    %|      line_1: "123 Main St.",|
+              expected_line %|-     city: "Hill Valley",|
+              actual_line   %|+     city: "Burbank",|
+              plain_line    %|      state: "CA",|
+              expected_line %|-     zip: "90382"|
+              actual_line   %|+     zip: "90210"|
+              plain_line    %|    }|
+              plain_line    %|  }|
             },
           )
 
@@ -245,7 +245,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
                 zip: "90210"
               )
             }
-            actual = {
+            actual   = {
               name: "Marty McFly",
               address: {
                 line_1: "123 Main St.",
@@ -267,13 +267,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|{ name: "Marty McFly", address: { line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" } }|
+                plain    %|    Expected |
+                actual   %|{ name: "Marty McFly", address: { line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" } }|
               end
 
               line do
-                plain "not to match "
-                alpha %|{ name: "Marty McFly", address: #<a hash including (city: "Burbank", zip: "90210")> }|
+                plain    %|not to match |
+                expected %|{ name: "Marty McFly", address: #<a hash including (city: "Burbank", zip: "90210")> }|
               end
             },
           )
@@ -285,7 +285,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
       end
     end
 
-    context "and the corresponding actual value is not a hash" do
+    context "and the corresponding actual   value is not a hash" do
       it "produces the correct failure message" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -296,7 +296,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
                 zip: "90382"
               )
             }
-            actual = {
+            actual   = {
               name: "Marty McFly",
               address: nil
             }
@@ -312,24 +312,24 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "Marty McFly", address: nil }|
+                plain    %|Expected |
+                actual   %|{ name: "Marty McFly", address: nil }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "Marty McFly", address: #<a hash including (city: "Hill Valley", zip: "90382")> }|
+                plain    %|to match |
+                expected %|{ name: "Marty McFly", address: #<a hash including (city: "Hill Valley", zip: "90382")> }|
               end
             },
             diff: proc {
-              plain_line %!  {!
-              plain_line %!    name: "Marty McFly",!
-              alpha_line %!-   address: #<a hash including (!
-              alpha_line %!-     city: "Hill Valley",!
-              alpha_line %!-     zip: "90382"!
-              alpha_line %!-   )>!
-              beta_line  %!+   address: nil!
-              plain_line %!  }!
+              plain_line    %!  {!
+              plain_line    %!    name: "Marty McFly",!
+              expected_line %!-   address: #<a hash including (!
+              expected_line %!-     city: "Hill Valley",!
+              expected_line %!-     zip: "90382"!
+              expected_line %!-   )>!
+              actual_line   %!+   address: nil!
+              plain_line    %!  }!
             },
           )
 
@@ -347,7 +347,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_including("a")
-            actual = ["b"]
+            actual   = ["b"]
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -360,19 +360,19 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["b"]|
-                plain " to match "
-                alpha %|#<a collection including ("a")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|["b"]|
+                plain    %| to match |
+                expected %|#<a collection including ("a")>|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "b"|
-              # alpha_line %|-   "a",|   # FIXME
-              alpha_line %|-   "a"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "b"|
+              # expected_line %|-   "a",|   # FIXME
+              expected_line %|-   "a"|
+              plain_line    %|  ]|
             },
           )
 
@@ -386,7 +386,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_including("b")
-            actual = ["b"]
+            actual   = ["b"]
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -399,11 +399,11 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).not_to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["b"]|
-                plain " not to match "
-                alpha %|#<a collection including ("b")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|["b"]|
+                plain    %| not to match |
+                expected %|#<a collection including ("b")>|
+                plain    %|.|
               end
             },
           )
@@ -420,7 +420,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_including("milk", "bread")
-            actual = ["milk", "toast", "eggs", "cheese", "English muffins"]
+            actual   = ["milk", "toast", "eggs", "cheese", "English muffins"]
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -433,25 +433,25 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["milk", "toast", "eggs", "cheese", "English muffins"]|
+                plain    %|Expected |
+                actual   %|["milk", "toast", "eggs", "cheese", "English muffins"]|
               end
 
               line do
-                plain "to match "
-                alpha %|#<a collection including ("milk", "bread")>|
+                plain    %|to match |
+                expected %|#<a collection including ("milk", "bread")>|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "milk",|
-              plain_line %|    "toast",|
-              plain_line %|    "eggs",|
-              plain_line %|    "cheese",|
-              # plain_line %|    "English muffins",|  # FIXME
-              plain_line %|    "English muffins"|
-              alpha_line %|-   "bread"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "milk",|
+              plain_line    %|    "toast",|
+              plain_line    %|    "eggs",|
+              plain_line    %|    "cheese",|
+              # plain_line    %|    "English muffins",|  # FIXME
+              plain_line    %|    "English muffins"|
+              expected_line %|-   "bread"|
+              plain_line    %|  ]|
             },
           )
 
@@ -465,7 +465,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_including("milk", "toast")
-            actual = ["milk", "toast", "eggs", "cheese", "English muffins"]
+            actual   = ["milk", "toast", "eggs", "cheese", "English muffins"]
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -479,13 +479,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|["milk", "toast", "eggs", "cheese", "English muffins"]|
+                plain    %|    Expected |
+                actual   %|["milk", "toast", "eggs", "cheese", "English muffins"]|
               end
 
               line do
-                plain "not to match "
-                alpha %|#<a collection including ("milk", "toast")>|
+                plain    %|not to match |
+                expected %|#<a collection including ("milk", "toast")>|
               end
             },
           )
@@ -499,7 +499,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
   end
 
   context "when the expected value includes a collection-including-<something>" do
-    context "and the corresponding actual value is an array" do
+    context "and the corresponding actual   value is an array" do
       it "produces the correct failure message when used in the positive" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -507,7 +507,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_including("milk", "bread")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: ["milk", "toast", "eggs"]
             }
@@ -523,26 +523,26 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
+                plain    %|Expected |
+                actual   %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "shopping list", contents: #<a collection including ("milk", "bread")> }|
+                plain    %|to match |
+                expected %|{ name: "shopping list", contents: #<a collection including ("milk", "bread")> }|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    name: "shopping list",|
-              plain_line %|    contents: [|
-              plain_line %|      "milk",|
-              plain_line %|      "toast",|
-              # plain_line %|      "eggs",|     # FIXME
-              plain_line %|      "eggs"|
-              alpha_line %|-     "bread"|
-              plain_line %|    ]|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    name: "shopping list",|
+              plain_line    %|    contents: [|
+              plain_line    %|      "milk",|
+              plain_line    %|      "toast",|
+              # plain_line    %|      "eggs",|     # FIXME
+              plain_line    %|      "eggs"|
+              expected_line %|-     "bread"|
+              plain_line    %|    ]|
+              plain_line    %|  }|
             },
           )
 
@@ -559,7 +559,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_including("milk", "toast")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: ["milk", "toast", "eggs"]
             }
@@ -576,13 +576,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
+                plain    %|    Expected |
+                actual   %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
               end
 
               line do
-                plain "not to match "
-                alpha %|{ name: "shopping list", contents: #<a collection including ("milk", "toast")> }|
+                plain    %|not to match |
+                expected %|{ name: "shopping list", contents: #<a collection including ("milk", "toast")> }|
               end
             },
           )
@@ -594,7 +594,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
       end
     end
 
-    context "when the corresponding actual value is not an array" do
+    context "when the corresponding actual   value is not an array" do
       it "produces the correct failure message" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -602,7 +602,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_including("milk", "bread")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: nil
             }
@@ -618,24 +618,24 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "shopping list", contents: nil }|
+                plain    %|Expected |
+                actual   %|{ name: "shopping list", contents: nil }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "shopping list", contents: #<a collection including ("milk", "bread")> }|
+                plain    %|to match |
+                expected %|{ name: "shopping list", contents: #<a collection including ("milk", "bread")> }|
               end
             },
             diff: proc {
-              plain_line %!  {!
-              plain_line %!    name: "shopping list",!
-              alpha_line %!-   contents: #<a collection including (!
-              alpha_line %!-     "milk",!
-              alpha_line %!-     "bread"!
-              alpha_line %!-   )>!
-              beta_line  %!+   contents: nil!
-              plain_line %!  }!
+              plain_line    %!  {!
+              plain_line    %!    name: "shopping list",!
+              expected_line %!-   contents: #<a collection including (!
+              expected_line %!-     "milk",!
+              expected_line %!-     "bread"!
+              expected_line %!-   )>!
+              actual_line   %!+   contents: nil!
+              plain_line    %!  }!
             },
           )
 
@@ -653,7 +653,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = an_object_having_attributes(name: "b")
-            actual = A.new("a")
+            actual   = A.new("a")
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -666,19 +666,19 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<A name: "a">|
-                plain " to match "
-                alpha %|#<an object having attributes (name: "b")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<A name: "a">|
+                plain    %| to match |
+                expected %|#<an object having attributes (name: "b")>|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  #<A {|
-              # alpha_line %|-   name: "b",|  # FIXME
-              alpha_line %|-   name: "b"|
-              beta_line  %|+   name: "a"|
-              plain_line %|  }>|
+              plain_line    %|  #<A {|
+              # expected_line %|-   name: "b",|  # FIXME
+              expected_line %|-   name: "b"|
+              actual_line   %|+   name: "a"|
+              plain_line    %|  }>|
             },
           )
 
@@ -692,7 +692,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = an_object_having_attributes(name: "b")
-            actual = A.new("b")
+            actual   = A.new("b")
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -705,11 +705,11 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).not_to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<A name: "b">|
-                plain " not to match "
-                alpha %|#<an object having attributes (name: "b")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<A name: "b">|
+                plain    %| not to match |
+                expected %|#<an object having attributes (name: "b")>|
+                plain    %|.|
               end
             },
           )
@@ -732,7 +732,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               state: "CA",
               something_else: "blah"
             )
-            actual = SuperDiff::Test::ShippingAddress.new(
+            actual   = SuperDiff::Test::ShippingAddress.new(
               line_1: "456 Ponderosa Ct.",
               line_2: nil,
               city: "Hill Valley",
@@ -751,29 +751,29 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
+                plain    %|Expected |
+                actual   %|#<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382">|
               end
 
               line do
-                plain "to match "
-                alpha %|#<an object having attributes (line_1: "123 Main St.", city: "Oakland", zip: "91234", state: "CA", something_else: "blah")>|
+                plain    %|to match |
+                expected %|#<an object having attributes (line_1: "123 Main St.", city: "Oakland", zip: "91234", state: "CA", something_else: "blah")>|
               end
             },
             diff: proc {
-              plain_line %|  #<SuperDiff::Test::ShippingAddress {|
-              alpha_line %|-   line_1: "123 Main St.",|
-              beta_line  %|+   line_1: "456 Ponderosa Ct.",|
-              plain_line %|    line_2: nil,|
-              alpha_line %|-   city: "Oakland",|
-              beta_line  %|+   city: "Hill Valley",|
-              plain_line %|    state: "CA",|
-              # alpha_line %|-   zip: "91234",|  # FIXME
-              # beta_line  %|+   zip: "90382",|  # FIXME
-              alpha_line %|-   zip: "91234"|
-              beta_line  %|+   zip: "90382"|
-              alpha_line %|-   something_else: "blah"|
-              plain_line %|  }>|
+              plain_line    %|  #<SuperDiff::Test::ShippingAddress {|
+              expected_line %|-   line_1: "123 Main St.",|
+              actual_line   %|+   line_1: "456 Ponderosa Ct.",|
+              plain_line    %|    line_2: nil,|
+              expected_line %|-   city: "Oakland",|
+              actual_line   %|+   city: "Hill Valley",|
+              plain_line    %|    state: "CA",|
+              # expected_line %|-   zip: "91234",|  # FIXME
+              # actual_line   %|+   zip: "90382",|  # FIXME
+              expected_line %|-   zip: "91234"|
+              actual_line   %|+   zip: "90382"|
+              expected_line %|-   something_else: "blah"|
+              plain_line    %|  }>|
             },
           )
 
@@ -791,7 +791,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               city: "Oakland",
               zip: "91234"
             )
-            actual = SuperDiff::Test::ShippingAddress.new(
+            actual   = SuperDiff::Test::ShippingAddress.new(
               line_1: "123 Main St.",
               line_2: nil,
               city: "Oakland",
@@ -811,13 +811,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
+                plain    %|    Expected |
+                actual   %|#<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234">|
               end
 
               line do
-                plain "not to match "
-                alpha %|#<an object having attributes (line_1: "123 Main St.", city: "Oakland", zip: "91234")>|
+                plain    %|not to match |
+                expected %|#<an object having attributes (line_1: "123 Main St.", city: "Oakland", zip: "91234")>|
               end
             },
           )
@@ -844,7 +844,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               something_else: "blah"
             )
           }
-          actual = {
+          actual   = {
             name: "Marty McFly",
             shipping_address: SuperDiff::Test::ShippingAddress.new(
               line_1: "456 Ponderosa Ct.",
@@ -866,31 +866,31 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
           snippet: %|expect(actual).to match(expected)|,
           expectation: proc {
             line do
-              plain "Expected "
-              beta %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382"> }|
+              plain    %|Expected |
+              actual   %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::ShippingAddress line_1: "456 Ponderosa Ct.", line_2: nil, city: "Hill Valley", state: "CA", zip: "90382"> }|
             end
 
             line do
-              plain "to match "
-              alpha %|{ name: "Marty McFly", shipping_address: #<an object having attributes (line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234", something_else: "blah")> }|
+              plain    %|to match |
+              expected %|{ name: "Marty McFly", shipping_address: #<an object having attributes (line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234", something_else: "blah")> }|
             end
           },
           diff: proc {
-            plain_line %|  {|
-            plain_line %|    name: "Marty McFly",|
-            plain_line %|    shipping_address: #<SuperDiff::Test::ShippingAddress {|
-            alpha_line %|-     line_1: "123 Main St.",|
-            beta_line  %|+     line_1: "456 Ponderosa Ct.",|
-            plain_line %|      line_2: nil,|
-            alpha_line %|-     city: "Oakland",|
-            beta_line  %|+     city: "Hill Valley",|
-            plain_line %|      state: "CA",|
-            # alpha_line %|-     zip: "91234",|  # FIXME
-            alpha_line %|-     zip: "91234"|
-            beta_line  %|+     zip: "90382"|
-            alpha_line %|-     something_else: "blah"|
-            plain_line %|    }>|
-            plain_line %|  }|
+            plain_line    %|  {|
+            plain_line    %|    name: "Marty McFly",|
+            plain_line    %|    shipping_address: #<SuperDiff::Test::ShippingAddress {|
+            expected_line %|-     line_1: "123 Main St.",|
+            actual_line   %|+     line_1: "456 Ponderosa Ct.",|
+            plain_line    %|      line_2: nil,|
+            expected_line %|-     city: "Oakland",|
+            actual_line   %|+     city: "Hill Valley",|
+            plain_line    %|      state: "CA",|
+            # expected_line %|-     zip: "91234",|  # FIXME
+            expected_line %|-     zip: "91234"|
+            actual_line   %|+     zip: "90382"|
+            expected_line %|-     something_else: "blah"|
+            plain_line    %|    }>|
+            plain_line    %|  }|
           },
         )
 
@@ -912,7 +912,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               zip: "91234"
             )
           }
-          actual = {
+          actual   = {
             name: "Marty McFly",
             shipping_address: SuperDiff::Test::ShippingAddress.new(
               line_1: "123 Main St.",
@@ -935,13 +935,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "    Expected "
-              beta %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234"> }|
+              plain    %|    Expected |
+              actual   %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::ShippingAddress line_1: "123 Main St.", line_2: nil, city: "Oakland", state: "CA", zip: "91234"> }|
             end
 
             line do
-              plain "not to match "
-              alpha %|{ name: "Marty McFly", shipping_address: #<an object having attributes (line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")> }|
+              plain    %|not to match |
+              expected %|{ name: "Marty McFly", shipping_address: #<an object having attributes (line_1: "123 Main St.", city: "Oakland", state: "CA", zip: "91234")> }|
             end
           },
         )
@@ -959,7 +959,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_containing_exactly("a")
-            actual = ["b"]
+            actual   = ["b"]
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -972,18 +972,18 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["b"]|
-                plain " to match "
-                alpha %|#<a collection containing exactly ("a")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|["b"]|
+                plain    %| to match |
+                expected %|#<a collection containing exactly ("a")>|
+                plain    %|.|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              beta_line  %|+   "b",|
-              alpha_line %|-   "a"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              actual_line   %|+   "b",|
+              expected_line %|-   "a"|
+              plain_line    %|  ]|
             },
           )
 
@@ -997,7 +997,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_containing_exactly("b")
-            actual = ["b"]
+            actual   = ["b"]
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -1010,11 +1010,11 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).not_to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["b"]|
-                plain " not to match "
-                alpha %|#<a collection containing exactly ("b")>|
-                plain "."
+                plain    %|Expected |
+                actual   %|["b"]|
+                plain    %| not to match |
+                expected %|#<a collection containing exactly ("b")>|
+                plain    %|.|
               end
             },
           )
@@ -1031,7 +1031,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_containing_exactly("milk", "bread")
-            actual = ["milk", "toast", "eggs", "cheese", "English muffins"]
+            actual   = ["milk", "toast", "eggs", "cheese", "English muffins"]
             expect(actual).to match(expected)
           TEST
           program = make_plain_test_program(
@@ -1044,24 +1044,24 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|["milk", "toast", "eggs", "cheese", "English muffins"]|
+                plain    %|Expected |
+                actual   %|["milk", "toast", "eggs", "cheese", "English muffins"]|
               end
 
               line do
-                plain "to match "
-                alpha %|#<a collection containing exactly ("milk", "bread")>|
+                plain    %|to match |
+                expected %|#<a collection containing exactly ("milk", "bread")>|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    "milk",|
-              beta_line  %|+   "toast",|
-              beta_line  %|+   "eggs",|
-              beta_line  %|+   "cheese",|
-              beta_line  %|+   "English muffins",|
-              alpha_line %|-   "bread"|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    "milk",|
+              actual_line   %|+   "toast",|
+              actual_line   %|+   "eggs",|
+              actual_line   %|+   "cheese",|
+              actual_line   %|+   "English muffins",|
+              expected_line %|-   "bread"|
+              plain_line    %|  ]|
             },
           )
 
@@ -1075,7 +1075,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
             expected = a_collection_containing_exactly("milk", "eggs", "toast")
-            actual = ["milk", "toast", "eggs"]
+            actual   = ["milk", "toast", "eggs"]
             expect(actual).not_to match(expected)
           TEST
           program = make_plain_test_program(
@@ -1089,13 +1089,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|["milk", "toast", "eggs"]|
+                plain    %|    Expected |
+                actual   %|["milk", "toast", "eggs"]|
               end
 
               line do
-                plain "not to match "
-                alpha %|#<a collection containing exactly ("milk", "eggs", "toast")>|
+                plain    %|not to match |
+                expected %|#<a collection containing exactly ("milk", "eggs", "toast")>|
               end
             },
           )
@@ -1109,7 +1109,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
   end
 
   context "when the expected value includes a collection-containing-exactly-<something>" do
-    context "and the corresponding actual value is an array" do
+    context "and the corresponding actual   value is an array" do
       it "produces the correct failure message when used in the positive" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -1117,7 +1117,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_containing_exactly("milk", "bread")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: ["milk", "toast", "eggs"]
             }
@@ -1133,25 +1133,25 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
+                plain    %|Expected |
+                actual   %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "bread")> }|
+                plain    %|to match |
+                expected %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "bread")> }|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    name: "shopping list",|
-              plain_line %|    contents: [|
-              plain_line %|      "milk",|
-              beta_line  %|+     "toast",|
-              beta_line  %|+     "eggs",|
-              alpha_line %|-     "bread"|
-              plain_line %|    ]|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    name: "shopping list",|
+              plain_line    %|    contents: [|
+              plain_line    %|      "milk",|
+              actual_line   %|+     "toast",|
+              actual_line   %|+     "eggs",|
+              expected_line %|-     "bread"|
+              plain_line    %|    ]|
+              plain_line    %|  }|
             },
           )
 
@@ -1168,7 +1168,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_containing_exactly("milk", "eggs", "toast")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: ["milk", "toast", "eggs"]
             }
@@ -1185,13 +1185,13 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "    Expected "
-                beta %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
+                plain    %|    Expected |
+                actual   %|{ name: "shopping list", contents: ["milk", "toast", "eggs"] }|
               end
 
               line do
-                plain "not to match "
-                alpha %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "eggs", "toast")> }|
+                plain    %|not to match |
+                expected %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "eggs", "toast")> }|
               end
             },
           )
@@ -1203,7 +1203,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
       end
     end
 
-    context "when the corresponding actual value is not an array" do
+    context "when the corresponding actual   value is not an array" do
       it "produces the correct failure message" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
@@ -1211,7 +1211,7 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
               name: "shopping list",
               contents: a_collection_containing_exactly("milk", "bread")
             }
-            actual = {
+            actual   = {
               name: "shopping list",
               contents: nil
             }
@@ -1227,24 +1227,24 @@ RSpec.describe "Integration with RSpec's #match matcher", type: :integration do
             snippet: %|expect(actual).to match(expected)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "shopping list", contents: nil }|
+                plain    %|Expected |
+                actual   %|{ name: "shopping list", contents: nil }|
               end
 
               line do
-                plain "to match "
-                alpha %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "bread")> }|
+                plain    %|to match |
+                expected %|{ name: "shopping list", contents: #<a collection containing exactly ("milk", "bread")> }|
               end
             },
             diff: proc {
-              plain_line %!  {!
-              plain_line %!    name: "shopping list",!
-              alpha_line %!-   contents: #<a collection containing exactly (!
-              alpha_line %!-     "milk",!
-              alpha_line %!-     "bread"!
-              alpha_line %!-   )>!
-              beta_line  %!+   contents: nil!
-              plain_line %!  }!
+              plain_line    %!  {!
+              plain_line    %!    name: "shopping list",!
+              expected_line %!-   contents: #<a collection containing exactly (!
+              expected_line %!-     "milk",!
+              expected_line %!-     "bread"!
+              expected_line %!-   )>!
+              actual_line   %!+   contents: nil!
+              plain_line    %!  }!
             },
           )
 

--- a/spec/integration/rspec/raise_error_matcher_spec.rb
+++ b/spec/integration/rspec/raise_error_matcher_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 snippet: %|expect { raise StandardError.new('boo') }.to raise_error(RuntimeError)|,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<StandardError "boo">|
-                    plain " to match "
-                    alpha %|#<RuntimeError>|
-                    plain "."
+                    plain    %|Expected raised exception |
+                    actual   %|#<StandardError "boo">|
+                    plain    %| to match |
+                    expected %|#<RuntimeError>|
+                    plain    %|.|
                   end
                 },
               )
@@ -53,13 +53,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<StandardError "this is a super super super long message">|
+                    plain    %|Expected raised exception |
+                    actual   %|#<StandardError "this is a super super super long message">|
                   end
 
                   line do
-                    plain "                 to match "
-                    alpha %|#<RuntimeError>|
+                    plain    %|                 to match |
+                    expected %|#<RuntimeError>|
                   end
                 },
               )
@@ -88,9 +88,9 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               snippet: %|expect { }.to raise_error(RuntimeError)|,
               expectation: proc {
                 line do
-                  plain "Expected block to raise error "
-                  alpha %|#<RuntimeError>|
-                  plain "."
+                  plain    %|Expected block to raise error |
+                  expected %|#<RuntimeError>|
+                  plain    %|.|
                 end
               },
             )
@@ -120,11 +120,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               snippet: %|expect { raise StandardError.new('boo') }.not_to raise_error(StandardError)|,
               expectation: proc {
                 line do
-                  plain "Expected raised exception "
-                  beta  %|#<StandardError "boo">|
-                  plain " not to match "
-                  alpha %|#<StandardError>|
-                  plain "."
+                  plain    %|Expected raised exception |
+                  actual   %|#<StandardError "boo">|
+                  plain    %| not to match |
+                  expected %|#<StandardError>|
+                  plain    %|.|
                 end
               },
             )
@@ -153,13 +153,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               newline_before_expectation: true,
               expectation: proc {
                 line do
-                  plain "Expected raised exception "
-                  beta  %|#<StandardError "this is a super super long message">|
+                  plain    %|Expected raised exception |
+                  actual   %|#<StandardError "this is a super super long message">|
                 end
 
                 line do
-                  plain "             not to match "
-                  alpha %|#<StandardError>|
+                  plain    %|             not to match |
+                  expected %|#<StandardError>|
                 end
               },
             )
@@ -192,11 +192,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 snippet: %|expect { raise 'boo' }.to raise_error('hell')|,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<RuntimeError "boo">|
-                    plain " to match "
-                    alpha %|#<Exception "hell">|
-                    plain "."
+                    plain    %|Expected raised exception |
+                    actual   %|#<RuntimeError "boo">|
+                    plain    %| to match |
+                    expected %|#<Exception "hell">|
+                    plain    %|.|
                   end
                 },
               )
@@ -228,13 +228,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "Expected raised exception "
-                      beta  %|#<RuntimeError "some really really really long message">|
+                      plain    %|Expected raised exception |
+                      actual   %|#<RuntimeError "some really really really long message">|
                     end
 
                     line do
-                      plain "                 to match "
-                      alpha %|#<Exception "whatever">|
+                      plain    %|                 to match |
+                      expected %|#<Exception "whatever">|
                     end
                   },
                 )
@@ -270,19 +270,19 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                   snippet: %|expect { raise(actual_message) }.to raise_error(expected_message)|,
                   expectation: proc {
                     line do
-                      plain "Expected raised exception "
-                      beta  %|#<RuntimeError "This is fun\\nSo is this">|
+                      plain    %|Expected raised exception |
+                      actual   %|#<RuntimeError "This is fun\\nSo is this">|
                     end
 
                     line do
-                      plain "                 to match "
-                      alpha %|#<Exception "This is fun\\nAnd so is this">|
+                      plain    %|                 to match |
+                      expected %|#<Exception "This is fun\\nAnd so is this">|
                     end
                   },
                   diff: proc {
-                    plain_line %|  This is fun\\n|
-                    alpha_line %|- And so is this|
-                    beta_line  %|+ So is this|
+                    plain_line    %|  This is fun\\n|
+                    expected_line %|- And so is this|
+                    actual_line   %|+ So is this|
                   },
                 )
 
@@ -312,9 +312,9 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 snippet: %|expect { }.to raise_error('hell')|,
                 expectation: proc {
                   line do
-                    plain "Expected block to raise error "
-                    alpha %|#<Exception "hell">|
-                    plain "."
+                    plain    %|Expected block to raise error |
+                    expected %|#<Exception "hell">|
+                    plain    %|.|
                   end
                 },
               )
@@ -345,13 +345,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "      Expected "
-                      plain "block"
+                      plain    %|      Expected |
+                      plain    %|block|
                     end
 
                     line do
-                      plain "to raise error "
-                      alpha %|#<Exception "this is a super super super super super super long message">|
+                      plain    %|to raise error |
+                      expected %|#<Exception "this is a super super super super super super long message">|
                     end
                   },
                 )
@@ -381,13 +381,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                   newline_before_expectation: true,
                   expectation: proc {
                     line do
-                      plain "Expected raised exception "
-                      beta  %|#<RuntimeError "some really long message">|
+                      plain    %|Expected raised exception |
+                      actual   %|#<RuntimeError "some really long message">|
                     end
 
                     line do
-                      plain "             not to match "
-                      alpha %|#<Exception "some really long message">|
+                      plain    %|             not to match |
+                      expected %|#<Exception "some really long message">|
                     end
                   },
                 )
@@ -419,11 +419,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               snippet: %|expect { raise 'boo' }.not_to raise_error('boo')|,
               expectation: proc {
                 line do
-                  plain "Expected raised exception "
-                  beta  %|#<RuntimeError "boo">|
-                  plain " not to match "
-                  alpha %|#<Exception "boo">|
-                  plain "."
+                  plain    %|Expected raised exception |
+                  actual   %|#<RuntimeError "boo">|
+                  plain    %| not to match |
+                  expected %|#<Exception "boo">|
+                  plain    %|.|
                 end
               },
             )
@@ -454,13 +454,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<RuntimeError "some really long message">|
+                    plain    %|Expected raised exception |
+                    actual   %|#<RuntimeError "some really long message">|
                   end
 
                   line do
-                    plain "             not to match "
-                    alpha %|#<Exception "some really long message">|
+                    plain    %|             not to match |
+                    expected %|#<Exception "some really long message">|
                   end
                 },
               )
@@ -493,13 +493,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<RuntimeError "This is fun\\nSo is this">|
+                    plain    %|Expected raised exception |
+                    actual   %|#<RuntimeError "This is fun\\nSo is this">|
                   end
 
                   line do
-                    plain "             not to match "
-                    alpha %|#<Exception "This is fun\\nSo is this">|
+                    plain    %|             not to match |
+                    expected %|#<Exception "This is fun\\nSo is this">|
                   end
                 },
               )
@@ -534,11 +534,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 snippet: %|expect(&block).to raise_error(RuntimeError, 'b')|,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<StandardError "a">|
-                    plain " to match "
-                    alpha %|#<RuntimeError "b">|
-                    plain "."
+                    plain    %|Expected raised exception |
+                    actual   %|#<StandardError "a">|
+                    plain    %| to match |
+                    expected %|#<RuntimeError "b">|
+                    plain    %|.|
                   end
                 },
               )
@@ -568,13 +568,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "Expected raised exception "
-                    beta  %|#<StandardError "this is a long message">|
+                    plain    %|Expected raised exception |
+                    actual   %|#<StandardError "this is a long message">|
                   end
 
                   line do
-                    plain "                 to match "
-                    alpha %|#<RuntimeError "this is another long message">|
+                    plain    %|                 to match |
+                    expected %|#<RuntimeError "this is another long message">|
                   end
                 },
               )
@@ -604,9 +604,9 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 snippet: %|expect { }.to raise_error(RuntimeError, 'b')|,
                 expectation: proc {
                   line do
-                    plain "Expected block to raise error "
-                    alpha %|#<RuntimeError "b">|
-                    plain "."
+                    plain    %|Expected block to raise error |
+                    expected %|#<RuntimeError "b">|
+                    plain    %|.|
                   end
                 },
               )
@@ -635,13 +635,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
                 newline_before_expectation: true,
                 expectation: proc {
                   line do
-                    plain "      Expected "
-                    plain "block"
+                    plain    %|      Expected |
+                    plain    %|block|
                   end
 
                   line do
-                    plain "to raise error "
-                    alpha %|#<RuntimeError "this is a super super super super super super long message">|
+                    plain    %|to raise error |
+                    expected %|#<RuntimeError "this is a super super super super super super long message">|
                   end
                 },
               )
@@ -673,11 +673,11 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               snippet: %|expect(&block).not_to raise_error(StandardError, 'a')|,
               expectation: proc {
                 line do
-                  plain "Expected raised exception "
-                  beta  %|#<StandardError "a">|
-                  plain " not to match "
-                  alpha %|#<StandardError "a">|
-                  plain "."
+                  plain    %|Expected raised exception |
+                  actual   %|#<StandardError "a">|
+                  plain    %| not to match |
+                  expected %|#<StandardError "a">|
+                  plain    %|.|
                 end
               },
             )
@@ -707,13 +707,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher", type: :integrati
               newline_before_expectation: true,
               expectation: proc {
                 line do
-                  plain "Expected raised exception "
-                  beta  %|#<StandardError "this is a long message">|
+                  plain    %|Expected raised exception |
+                  actual   %|#<StandardError "this is a long message">|
                 end
 
                 line do
-                  plain "             not to match "
-                  alpha %|#<StandardError "this is a long message">|
+                  plain    %|             not to match |
+                  expected %|#<StandardError "this is a long message">|
                 end
               },
             )

--- a/spec/integration/rspec/respond_to_matcher_spec.rb
+++ b/spec/integration/rspec/respond_to_matcher_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: snippet,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| to respond to |
+                expected %|:foo|
+                plain    %|.|
               end
             },
           )
@@ -45,11 +45,11 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: snippet,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " not to respond to "
-                alpha %|:inspect|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| not to respond to |
+                expected %|:inspect|
+                plain    %|.|
               end
             },
           )
@@ -78,25 +78,25 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|#<Double :something_really_long>|
+                plain    %|     Expected |
+                actual   %|#<Double :something_really_long>|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain ", "
-                alpha %|:bar|
-                plain ", "
-                alpha %|:baz|
-                plain ", "
-                alpha %|:qux|
-                plain ", "
-                alpha %|:fizz|
-                plain ", "
-                alpha %|:buzz|
-                plain " and "
-                alpha %|:zing|
+                plain    %|to respond to |
+                expected %|:foo|
+                plain    %|, |
+                expected %|:bar|
+                plain    %|, |
+                expected %|:baz|
+                plain    %|, |
+                expected %|:qux|
+                plain    %|, |
+                expected %|:fizz|
+                plain    %|, |
+                expected %|:buzz|
+                plain    %| and |
+                expected %|:zing|
               end
             },
           )
@@ -128,15 +128,15 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "         Expected "
-                beta %|#<B>|
+                plain    %|         Expected |
+                actual   %|#<B>|
               end
 
               line do
-                plain "not to respond to "
-                alpha %|:some_really_long_method_and_stuff|
-                plain " and "
-                alpha %|:another_method_or_whatever|
+                plain    %|not to respond to |
+                expected %|:some_really_long_method_and_stuff|
+                plain    %| and |
+                expected %|:another_method_or_whatever|
               end
             },
           )
@@ -167,13 +167,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(double).to respond_to(:foo).with(3).arguments|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|3|
-                plain " arguments."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|3|
+                plain    %| arguments.|
               end
             },
           )
@@ -203,13 +203,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(B.new).not_to respond_to(:foo).with(3).arguments|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<B>|
-                plain " not to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|3|
-                plain " arguments."
+                plain    %|Expected |
+                actual   %|#<B>|
+                plain    %| not to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|3|
+                plain    %| arguments.|
               end
             },
           )
@@ -239,24 +239,24 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|#<Double :something_really_long>|
+                plain    %|     Expected |
+                actual   %|#<Double :something_really_long>|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain ", "
-                alpha %|:bar|
-                plain ", "
-                alpha %|:baz|
-                plain ", "
-                alpha %|:fizz|
-                plain " and "
-                alpha %|:buzz|
-                plain " with "
-                alpha %|3|
-                plain " arguments"
+                plain    %|to respond to |
+                expected %|:foo|
+                plain    %|, |
+                expected %|:bar|
+                plain    %|, |
+                expected %|:baz|
+                plain    %|, |
+                expected %|:fizz|
+                plain    %| and |
+                expected %|:buzz|
+                plain    %| with |
+                expected %|3|
+                plain    %| arguments|
               end
             },
           )
@@ -288,18 +288,18 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "         Expected "
-                beta %|#<B>|
+                plain    %|         Expected |
+                actual   %|#<B>|
               end
 
               line do
-                plain "not to respond to "
-                alpha %|:some_really_long_method_and_stuff|
-                plain " and "
-                alpha %|:another_method_or_whatever|
-                plain " with "
-                alpha %|3|
-                plain " arguments"
+                plain    %|not to respond to |
+                expected %|:some_really_long_method_and_stuff|
+                plain    %| and |
+                expected %|:another_method_or_whatever|
+                plain    %| with |
+                expected %|3|
+                plain    %| arguments|
               end
             },
           )
@@ -330,13 +330,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(double).to respond_to(:foo).with_keywords(:bar)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain " with keyword "
-                alpha %|:bar|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| to respond to |
+                expected %|:foo|
+                plain    %| with keyword |
+                expected %|:bar|
+                plain    %|.|
               end
             },
           )
@@ -366,13 +366,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(B.new).not_to respond_to(:foo).with_keywords(:bar)|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<B>|
-                plain " not to respond to "
-                alpha %|:foo|
-                plain " with keyword "
-                alpha %|:bar|
-                plain "."
+                plain    %|Expected |
+                actual   %|#<B>|
+                plain    %| not to respond to |
+                expected %|:foo|
+                plain    %| with keyword |
+                expected %|:bar|
+                plain    %|.|
               end
             },
           )
@@ -402,25 +402,25 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|#<Double :something_really_long>|
+                plain    %|     Expected |
+                actual   %|#<Double :something_really_long>|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain ", "
-                alpha %|:bar|
-                plain ", "
-                alpha %|:baz|
-                plain ", "
-                alpha %|:fizz|
-                plain " and "
-                alpha %|:buzz|
-                plain " with keywords "
-                alpha %|:qux|
-                plain " and "
-                alpha %|:blargh|
+                plain    %|to respond to |
+                expected %|:foo|
+                plain    %|, |
+                expected %|:bar|
+                plain    %|, |
+                expected %|:baz|
+                plain    %|, |
+                expected %|:fizz|
+                plain    %| and |
+                expected %|:buzz|
+                plain    %| with keywords |
+                expected %|:qux|
+                plain    %| and |
+                expected %|:blargh|
               end
             },
           )
@@ -452,19 +452,19 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "         Expected "
-                beta %|#<B>|
+                plain    %|         Expected |
+                actual   %|#<B>|
               end
 
               line do
-                plain "not to respond to "
-                alpha %|:some_really_long_method_and_stuff|
-                plain " and "
-                alpha %|:another_method_or_whatever|
-                plain " with keywords "
-                alpha %|:foo|
-                plain " and "
-                alpha %|:bar|
+                plain    %|not to respond to |
+                expected %|:some_really_long_method_and_stuff|
+                plain    %| and |
+                expected %|:another_method_or_whatever|
+                plain    %| with keywords |
+                expected %|:foo|
+                plain    %| and |
+                expected %|:bar|
               end
             },
           )
@@ -495,13 +495,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(double).to respond_to(:foo).with_any_keywords|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|any|
-                plain " keywords."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|any|
+                plain    %| keywords.|
               end
             },
           )
@@ -531,13 +531,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(B.new).not_to respond_to(:foo).with_any_keywords|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<B>|
-                plain " not to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|any|
-                plain " keywords."
+                plain    %|Expected |
+                actual   %|#<B>|
+                plain    %| not to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|any|
+                plain    %| keywords.|
               end
             },
           )
@@ -567,26 +567,26 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|#<Double :something_really_long>|
+                plain    %|     Expected |
+                actual   %|#<Double :something_really_long>|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain ", "
-                alpha %|:bar|
-                plain ", "
-                alpha %|:baz|
-                plain ", "
-                alpha %|:qux|
-                plain ", "
-                alpha %|:fizz|
-                plain " and "
-                alpha %|:buzz|
-                plain " with "
-                alpha %|any|
-                plain " keywords "
+                plain    %|to respond to |
+                expected %|:foo|
+                plain    %|, |
+                expected %|:bar|
+                plain    %|, |
+                expected %|:baz|
+                plain    %|, |
+                expected %|:qux|
+                plain    %|, |
+                expected %|:fizz|
+                plain    %| and |
+                expected %|:buzz|
+                plain    %| with |
+                expected %|any|
+                plain    %| keywords |
               end
             },
           )
@@ -618,18 +618,18 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "         Expected "
-                beta %|#<B>|
+                plain    %|         Expected |
+                actual   %|#<B>|
               end
 
               line do
-                plain "not to respond to "
-                alpha %|:some_really_long_method_and_stuff|
-                plain " and "
-                alpha %|:another_method_or_whatever|
-                plain " with "
-                alpha %|any|
-                plain " keywords "
+                plain    %|not to respond to |
+                expected %|:some_really_long_method_and_stuff|
+                plain    %| and |
+                expected %|:another_method_or_whatever|
+                plain    %| with |
+                expected %|any|
+                plain    %| keywords |
               end
             },
           )
@@ -660,13 +660,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(double).to respond_to(:foo).with_unlimited_arguments|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<Double (anonymous)>|
-                plain " to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|unlimited|
-                plain " arguments."
+                plain    %|Expected |
+                actual   %|#<Double (anonymous)>|
+                plain    %| to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|unlimited|
+                plain    %| arguments.|
               end
             },
           )
@@ -696,13 +696,13 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             snippet: %|expect(B.new).not_to respond_to(:foo).with_unlimited_arguments|,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<B>|
-                plain " not to respond to "
-                alpha %|:foo|
-                plain " with "
-                alpha %|unlimited|
-                plain " arguments."
+                plain    %|Expected |
+                actual   %|#<B>|
+                plain    %| not to respond to |
+                expected %|:foo|
+                plain    %| with |
+                expected %|unlimited|
+                plain    %| arguments.|
               end
             },
           )
@@ -732,20 +732,20 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "     Expected "
-                beta %|#<Double :something_really_long>|
+                plain    %|     Expected |
+                actual   %|#<Double :something_really_long>|
               end
 
               line do
-                plain "to respond to "
-                alpha %|:foo|
-                plain ", "
-                alpha %|:bar|
-                plain " and "
-                alpha %|:baz|
-                plain " with "
-                alpha %|unlimited|
-                plain " arguments"
+                plain    %|to respond to |
+                expected %|:foo|
+                plain    %|, |
+                expected %|:bar|
+                plain    %| and |
+                expected %|:baz|
+                plain    %| with |
+                expected %|unlimited|
+                plain    %| arguments|
               end
             },
           )
@@ -777,18 +777,18 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "         Expected "
-                beta %|#<B>|
+                plain    %|         Expected |
+                actual   %|#<B>|
               end
 
               line do
-                plain "not to respond to "
-                alpha %|:some_really_long_method_and_stuff|
-                plain " and "
-                alpha %|:another_method_or_whatever|
-                plain " with "
-                alpha %|unlimited|
-                plain " arguments"
+                plain    %|not to respond to |
+                expected %|:some_really_long_method_and_stuff|
+                plain    %| and |
+                expected %|:another_method_or_whatever|
+                plain    %| with |
+                expected %|unlimited|
+                plain    %| arguments|
               end
             },
           )
@@ -819,22 +819,22 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "     Expected "
-              beta %|#<Double :something_really_long>|
+              plain    %|     Expected |
+              actual   %|#<Double :something_really_long>|
             end
 
             line do
-              plain "to respond to "
-              alpha %|:foo|
-              plain ", "
-              alpha %|:bar|
-              plain " and "
-              alpha %|:baz|
-              plain " with "
-              alpha %|any|
-              plain " keywords and "
-              alpha %|unlimited|
-              plain " arguments"
+              plain    %|to respond to |
+              expected %|:foo|
+              plain    %|, |
+              expected %|:bar|
+              plain    %| and |
+              expected %|:baz|
+              plain    %| with |
+              expected %|any|
+              plain    %| keywords and |
+              expected %|unlimited|
+              plain    %| arguments|
             end
           },
         )
@@ -867,22 +867,22 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "         Expected "
-              beta %|#<B>|
+              plain    %|         Expected |
+              actual   %|#<B>|
             end
 
             line do
-              plain "not to respond to "
-              alpha %|:foo|
-              plain ", "
-              alpha %|:bar|
-              plain " and "
-              alpha %|:baz|
-              plain " with "
-              alpha %|any|
-              plain " keywords and "
-              alpha %|unlimited|
-              plain " arguments"
+              plain    %|not to respond to |
+              expected %|:foo|
+              plain    %|, |
+              expected %|:bar|
+              plain    %| and |
+              expected %|:baz|
+              plain    %| with |
+              expected %|any|
+              plain    %| keywords and |
+              expected %|unlimited|
+              plain    %| arguments|
             end
           },
         )
@@ -912,24 +912,24 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "     Expected "
-              beta %|#<Double :something_really_long>|
+              plain    %|     Expected |
+              actual   %|#<Double :something_really_long>|
             end
 
             line do
-              plain "to respond to "
-              alpha %|:foo|
-              plain ", "
-              alpha %|:bar|
-              plain " and "
-              alpha %|:baz|
-              plain " with keywords "
-              alpha %|:qux|
-              plain " and "
-              alpha %|:blargh|
-              plain " and "
-              alpha %|unlimited|
-              plain " arguments"
+              plain    %|to respond to |
+              expected %|:foo|
+              plain    %|, |
+              expected %|:bar|
+              plain    %| and |
+              expected %|:baz|
+              plain    %| with keywords |
+              expected %|:qux|
+              plain    %| and |
+              expected %|:blargh|
+              plain    %| and |
+              expected %|unlimited|
+              plain    %| arguments|
             end
           },
         )
@@ -962,24 +962,24 @@ RSpec.describe "Integration with RSpec's #respond_to matcher", type: :integratio
           newline_before_expectation: true,
           expectation: proc {
             line do
-              plain "         Expected "
-              beta %|#<B>|
+              plain    %|         Expected |
+              actual   %|#<B>|
             end
 
             line do
-              plain "not to respond to "
-              alpha %|:foo|
-              plain ", "
-              alpha %|:bar|
-              plain " and "
-              alpha %|:baz|
-              plain " with keywords "
-              alpha %|:qux|
-              plain " and "
-              alpha %|:blargh|
-              plain " and "
-              alpha %|unlimited|
-              plain " arguments"
+              plain    %|not to respond to |
+              expected %|:foo|
+              plain    %|, |
+              expected %|:bar|
+              plain    %| and |
+              expected %|:baz|
+              plain    %| with keywords |
+              expected %|:qux|
+              plain    %| and |
+              expected %|:blargh|
+              plain    %| and |
+              expected %|unlimited|
+              plain    %| arguments|
             end
           },
         )

--- a/spec/integration/rspec/third_party_matcher_spec.rb
+++ b/spec/integration/rspec/third_party_matcher_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
                 red_line   "Here is the next line."
                 plain_line "  This part is indented, for whatever reason. It just kinda keeps"
                 plain_line "  going until we finish saying whatever it is we want to say."
-              }
+              },
             )
 
             expect(program).
@@ -50,10 +50,10 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
                 snippet: %|expect(:anything).to fail_with_paragraphed_failure_message|,
                 newline_before_expectation: true,
                 expectation: proc {
-                  red_line "This is a message that spans multiple paragraphs."
+                  red_line   "This is a message that spans multiple paragraphs."
                   newline
                   plain_line "Here is the next paragraph."
-                }
+                },
               )
 
               expect(program).
@@ -81,7 +81,7 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
                 expectation: proc {
                   red_line "This is a message that spans multiple lines."
                   red_line "Here is the next line."
-                }
+                },
               )
 
               expect(program).
@@ -142,7 +142,7 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
                 red_line   "Here is the next line."
                 plain_line "  This part is indented, for whatever reason. It just kinda keeps"
                 plain_line "  going until we finish saying whatever it is we want to say."
-              }
+              },
             )
 
             expect(program).
@@ -171,8 +171,8 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
                 expectation: proc {
                   red_line "This is a message that spans multiple paragraphs."
                   newline
-                  plain_line "Here is the next paragraph."
-                }
+                  plain_line    "Here is the next paragraph."
+                },
               )
 
               expect(program).
@@ -228,7 +228,7 @@ RSpec.describe "Integration with a third-party matcher", type: :integration do
             snippet: %|expect(:anything).not_to pass_with_singleline_failure_message|,
             expectation: proc {
               red_line "This is a message that spans only one line."
-            }
+            },
           )
 
           expect(program).

--- a/spec/integration/rspec/unhandled_errors_spec.rb
+++ b/spec/integration/rspec/unhandled_errors_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
             expectation: proc {
               red_line "RuntimeError:"
               indent by: 2 do
-                red_line "Some kind of error or whatever"
+                red_line   "Some kind of error or whatever"
                 newline
                 plain_line "This is another line"
               end
@@ -95,7 +95,7 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
           indent by: 5 do
             line do
               plain "1.1) "
-              bold "Failure/Error: "
+              bold  "Failure/Error: "
               plain snippet
             end
 
@@ -106,7 +106,7 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
               indent by: 2 do
                 red_line "Some kind of error or whatever"
                 newline
-                line "This is another line"
+                line     "This is another line"
               end
             end
           end
@@ -116,7 +116,7 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
           indent by: 5 do
             line do
               plain "1.2) "
-              bold "Failure/Error: "
+              bold  "Failure/Error: "
               plain snippet
             end
 
@@ -127,7 +127,7 @@ RSpec.describe "Integration with RSpec and unhandled errors", type: :integration
               indent by: 2 do
                 red_line "Some kind of error or whatever"
                 newline
-                line "This is another line"
+                line     "This is another line"
               end
             end
           end

--- a/spec/support/shared_examples/active_record.rb
+++ b/spec/support/shared_examples/active_record.rb
@@ -10,7 +10,7 @@ shared_examples_for "integration with ActiveRecord" do
               state: "CA",
               zip: "90382",
             )
-            actual = SuperDiff::Test::Models::ActiveRecord::ShippingAddress.new(
+            actual   = SuperDiff::Test::Models::ActiveRecord::ShippingAddress.new(
               line_1: "456 Ponderosa Ct.",
               city: "Oakland",
               state: "CA",
@@ -25,27 +25,27 @@ shared_examples_for "integration with ActiveRecord" do
             snippet: "expect(actual).to eq(expected)",
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234">|
+                plain    %|Expected |
+                actual   %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234">|
               end
 
               line do
-                plain "   to eq "
-                alpha %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
+                plain    %|   to eq |
+                expected %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
               end
             },
             diff: proc {
-              plain_line %|  #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
-              plain_line %|    id: nil,|
-              alpha_line %|-   city: "Hill Valley",|
-              beta_line %|+   city: "Oakland",|
-              alpha_line %|-   line_1: "123 Main St.",|
-              beta_line %|+   line_1: "456 Ponderosa Ct.",|
-              plain_line %|    line_2: "",|
-              plain_line %|    state: "CA",|
-              alpha_line %|-   zip: "90382"|
-              beta_line %|+   zip: "91234"|
-              plain_line %|  }>|
+              plain_line    %|  #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
+              plain_line    %|    id: nil,|
+              expected_line %|-   city: "Hill Valley",|
+              actual_line   %|+   city: "Oakland",|
+              expected_line %|-   line_1: "123 Main St.",|
+              actual_line   %|+   line_1: "456 Ponderosa Ct.",|
+              plain_line    %|    line_2: "",|
+              plain_line    %|    state: "CA",|
+              expected_line %|-   zip: "90382"|
+              actual_line   %|+   zip: "91234"|
+              plain_line    %|  }>|
             },
           )
 
@@ -66,7 +66,7 @@ shared_examples_for "integration with ActiveRecord" do
               state: "CA",
               zip: "90382",
             )
-            actual = SuperDiff::Test::Models::ActiveRecord::Person.new(
+            actual   = SuperDiff::Test::Models::ActiveRecord::Person.new(
               name: "Elliot",
               age: 31,
             )
@@ -80,13 +80,13 @@ shared_examples_for "integration with ActiveRecord" do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<SuperDiff::Test::Models::ActiveRecord::Person id: nil, age: 31, name: "Elliot">|
+                plain    %|Expected |
+                actual   %|#<SuperDiff::Test::Models::ActiveRecord::Person id: nil, age: 31, name: "Elliot">|
               end
 
               line do
-                plain "   to eq "
-                alpha %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
+                plain    %|   to eq |
+                expected %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
               end
             },
           )
@@ -108,7 +108,7 @@ shared_examples_for "integration with ActiveRecord" do
               state: "CA",
               zip: "90382"
             )
-            actual = nil
+            actual   = nil
             expect(actual).to eq(expected)
           TEST
           program = make_program(snippet, color_enabled: color_enabled)
@@ -119,13 +119,13 @@ shared_examples_for "integration with ActiveRecord" do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|nil|
+                plain    %|Expected |
+                actual   %|nil|
               end
 
               line do
-                plain "   to eq "
-                alpha %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
+                plain    %|   to eq |
+                expected %|#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">|
               end
             },
           )
@@ -150,7 +150,7 @@ shared_examples_for "integration with ActiveRecord" do
                 zip: "90382",
               )
             }
-            actual = {
+            actual   = {
               name: "Marty McFly",
               shipping_address: SuperDiff::Test::Models::ActiveRecord::ShippingAddress.new(
                 line_1: "456 Ponderosa Ct.",
@@ -168,30 +168,30 @@ shared_examples_for "integration with ActiveRecord" do
             snippet: "expect(actual).to eq(expected)",
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234"> }|
+                plain    %|Expected |
+                actual   %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234"> }|
               end
 
               line do
-                plain "   to eq "
-                alpha %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382"> }|
+                plain    %|   to eq |
+                expected %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382"> }|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    name: "Marty McFly",|
-              plain_line %|    shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
-              plain_line %|      id: nil,|
-              alpha_line %|-     city: "Hill Valley",|
-              beta_line %|+     city: "Oakland",|
-              alpha_line %|-     line_1: "123 Main St.",|
-              beta_line %|+     line_1: "456 Ponderosa Ct.",|
-              plain_line %|      line_2: "",|
-              plain_line %|      state: "CA",|
-              alpha_line %|-     zip: "90382"|
-              beta_line %|+     zip: "91234"|
-              plain_line %|    }>|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    name: "Marty McFly",|
+              plain_line    %|    shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
+              plain_line    %|      id: nil,|
+              expected_line %|-     city: "Hill Valley",|
+              actual_line   %|+     city: "Oakland",|
+              expected_line %|-     line_1: "123 Main St.",|
+              actual_line   %|+     line_1: "456 Ponderosa Ct.",|
+              plain_line    %|      line_2: "",|
+              plain_line    %|      state: "CA",|
+              expected_line %|-     zip: "90382"|
+              actual_line   %|+     zip: "91234"|
+              plain_line    %|    }>|
+              plain_line    %|  }|
             },
           )
 
@@ -215,7 +215,7 @@ shared_examples_for "integration with ActiveRecord" do
                 zip: "90382",
               )
             }
-            actual = {
+            actual   = {
               name: "Marty McFly",
               shipping_address: SuperDiff::Test::Models::ActiveRecord::Person.new(
                 name: "Elliot",
@@ -231,32 +231,32 @@ shared_examples_for "integration with ActiveRecord" do
             snippet: "expect(actual).to eq(expected)",
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::Person id: nil, age: 31, name: "Elliot"> }|
+                plain    %|Expected |
+                actual   %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::Person id: nil, age: 31, name: "Elliot"> }|
               end
 
               line do
-                plain "   to eq "
-                alpha %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382"> }|
+                plain    %|   to eq |
+                expected %|{ name: "Marty McFly", shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: nil, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382"> }|
               end
             },
             diff: proc {
-              plain_line %|  {|
-              plain_line %|    name: "Marty McFly",|
-              alpha_line %|-   shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
-              alpha_line %|-     id: nil,|
-              alpha_line %|-     city: "Hill Valley",|
-              alpha_line %|-     line_1: "123 Main St.",|
-              alpha_line %|-     line_2: "",|
-              alpha_line %|-     state: "CA",|
-              alpha_line %|-     zip: "90382"|
-              alpha_line %|-   }>|
-              beta_line %|+   shipping_address: #<SuperDiff::Test::Models::ActiveRecord::Person {|
-              beta_line %|+     id: nil,|
-              beta_line %|+     age: 31,|
-              beta_line %|+     name: "Elliot"|
-              beta_line %|+   }>|
-              plain_line %|  }|
+              plain_line    %|  {|
+              plain_line    %|    name: "Marty McFly",|
+              expected_line %|-   shipping_address: #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
+              expected_line %|-     id: nil,|
+              expected_line %|-     city: "Hill Valley",|
+              expected_line %|-     line_1: "123 Main St.",|
+              expected_line %|-     line_2: "",|
+              expected_line %|-     state: "CA",|
+              expected_line %|-     zip: "90382"|
+              expected_line %|-   }>|
+              actual_line   %|+   shipping_address: #<SuperDiff::Test::Models::ActiveRecord::Person {|
+              actual_line   %|+     id: nil,|
+              actual_line   %|+     age: 31,|
+              actual_line   %|+     name: "Elliot"|
+              actual_line   %|+   }>|
+              plain_line    %|  }|
             },
           )
 
@@ -287,7 +287,7 @@ shared_examples_for "integration with ActiveRecord" do
               )
             ]
             expected = [shipping_addresses.first]
-            actual = SuperDiff::Test::Models::ActiveRecord::ShippingAddress.all
+            actual   = SuperDiff::Test::Models::ActiveRecord::ShippingAddress.all
             expect(actual).to eq(expected)
           TEST
           program = make_program(snippet, color_enabled: color_enabled)
@@ -297,34 +297,34 @@ shared_examples_for "integration with ActiveRecord" do
             snippet: "expect(actual).to eq(expected)",
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|#<ActiveRecord::Relation [#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 1, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">, #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 2, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234">]>|
+                plain    %|Expected |
+                actual   %|#<ActiveRecord::Relation [#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 1, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">, #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 2, city: "Oakland", line_1: "456 Ponderosa Ct.", line_2: "", state: "CA", zip: "91234">]>|
               end
 
               line do
-                plain "   to eq "
-                alpha %|[#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 1, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">]|
+                plain    %|   to eq |
+                expected %|[#<SuperDiff::Test::Models::ActiveRecord::ShippingAddress id: 1, city: "Hill Valley", line_1: "123 Main St.", line_2: "", state: "CA", zip: "90382">]|
               end
             },
             diff: proc {
-              plain_line %|  #<ActiveRecord::Relation [|
-              plain_line %|    #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
-              plain_line %|      id: 1,|
-              plain_line %|      city: "Hill Valley",|
-              plain_line %|      line_1: "123 Main St.",|
-              plain_line %|      line_2: "",|
-              plain_line %|      state: "CA",|
-              plain_line %|      zip: "90382"|
-              plain_line %|    }>,|
-              beta_line %|+   #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
-              beta_line %|+     id: 2,|
-              beta_line %|+     city: "Oakland",|
-              beta_line %|+     line_1: "456 Ponderosa Ct.",|
-              beta_line %|+     line_2: "",|
-              beta_line %|+     state: "CA",|
-              beta_line %|+     zip: "91234"|
-              beta_line %|+   }>|
-              plain_line %|  ]>|
+              plain_line    %|  #<ActiveRecord::Relation [|
+              plain_line    %|    #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
+              plain_line    %|      id: 1,|
+              plain_line    %|      city: "Hill Valley",|
+              plain_line    %|      line_1: "123 Main St.",|
+              plain_line    %|      line_2: "",|
+              plain_line    %|      state: "CA",|
+              plain_line    %|      zip: "90382"|
+              plain_line    %|    }>,|
+              actual_line   %|+   #<SuperDiff::Test::Models::ActiveRecord::ShippingAddress {|
+              actual_line   %|+     id: 2,|
+              actual_line   %|+     city: "Oakland",|
+              actual_line   %|+     line_1: "456 Ponderosa Ct.",|
+              actual_line   %|+     line_2: "",|
+              actual_line   %|+     state: "CA",|
+              actual_line   %|+     zip: "91234"|
+              actual_line   %|+   }>|
+              plain_line    %|  ]>|
             },
           )
 
@@ -354,7 +354,7 @@ shared_examples_for "integration with ActiveRecord" do
               )
             ]
 
-            actual = [
+            actual   = [
               SuperDiff::Test::Models::ActiveRecord::Query.new(
                 results: SuperDiff::Test::Models::ActiveRecord::Person.all
               )
@@ -371,30 +371,30 @@ shared_examples_for "integration with ActiveRecord" do
             newline_before_expectation: true,
             expectation: proc {
               line do
-                plain "Expected "
-                beta %|[#<SuperDiff::Test::Models::ActiveRecord::Query @results=#<ActiveRecord::Relation [#<SuperDiff::Test::Models::ActiveRecord::Person id: 1, name: "Murphy", age: 20>]>>]|
+                plain    %|Expected |
+                actual   %|[#<SuperDiff::Test::Models::ActiveRecord::Query @results=#<ActiveRecord::Relation [#<SuperDiff::Test::Models::ActiveRecord::Person id: 1, name: "Murphy", age: 20>]>>]|
               end
 
               line do
-                plain "to match "
-                alpha %|[#<an object having attributes (results: [#<an object having attributes (name: "John", age: 19)>])>]|
+                plain    %|to match |
+                expected %|[#<an object having attributes (results: [#<an object having attributes (name: "John", age: 19)>])>]|
               end
             },
             diff: proc {
-              plain_line %|  [|
-              plain_line %|    #<SuperDiff::Test::Models::ActiveRecord::Query {|
-              plain_line %|      @results=#<ActiveRecord::Relation [|
-              plain_line %|        #<SuperDiff::Test::Models::ActiveRecord::Person {|
-              plain_line %|          id: 1,|
-              # alpha_line %|-         age: 19,|  # TODO
-              alpha_line %|-         age: 19|
-              beta_line  %|+         age: 20,|
-              alpha_line %|-         name: "John"|
-              beta_line  %|+         name: "Murphy"|
-              plain_line %|        }>|
-              plain_line %|      ]>|
-              plain_line %|    }>|
-              plain_line %|  ]|
+              plain_line    %|  [|
+              plain_line    %|    #<SuperDiff::Test::Models::ActiveRecord::Query {|
+              plain_line    %|      @results=#<ActiveRecord::Relation [|
+              plain_line    %|        #<SuperDiff::Test::Models::ActiveRecord::Person {|
+              plain_line    %|          id: 1,|
+              # expected_line %|-         age: 19,|  # TODO
+              expected_line %|-         age: 19|
+              actual_line   %|+         age: 20,|
+              expected_line %|-         name: "John"|
+              actual_line   %|+         name: "Murphy"|
+              plain_line    %|        }>|
+              plain_line    %|      ]>|
+              plain_line    %|    }>|
+              plain_line    %|  ]|
             },
           )
 

--- a/spec/support/shared_examples/hash_with_indifferent_access.rb
+++ b/spec/support/shared_examples/hash_with_indifferent_access.rb
@@ -1,6 +1,6 @@
 shared_examples_for "integration with HashWithIndifferentAccess" do
   describe "and RSpec's #eq matcher" do
-    context "when the actual value is a HashWithIndifferentAccess" do
+    context "when the actual   value is a HashWithIndifferentAccess" do
       context "and both hashes are one-dimensional" do
         context "and the expected hash contains symbol keys" do
           it "produces the correct output" do
@@ -12,7 +12,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "90382",
                 }
-                actual = HashWithIndifferentAccess.new({
+                actual   = HashWithIndifferentAccess.new({
                   line_1: "456 Ponderosa Ct.",
                   city: "Oakland",
                   state: "CA",
@@ -27,25 +27,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|Expected |
+                    actual   %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
+                    plain    %|   to eq |
+                    expected %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "123 Main St.",|
-                  beta_line  %|+   "line_1" => "456 Ponderosa Ct.",|
-                  alpha_line %|-   "city" => "Hill Valley",|
-                  beta_line  %|+   "city" => "Oakland",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "90382"|
-                  beta_line  %|+   "zip" => "91234"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "123 Main St.",|
+                  actual_line   %|+   "line_1" => "456 Ponderosa Ct.",|
+                  expected_line %|-   "city" => "Hill Valley",|
+                  actual_line   %|+   "city" => "Oakland",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "90382"|
+                  actual_line   %|+   "zip" => "91234"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -66,7 +66,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   "state" => "CA",
                   "zip" => "90382",
                 }
-                actual = HashWithIndifferentAccess.new({
+                actual   = HashWithIndifferentAccess.new({
                   line_1: "456 Ponderosa Ct.",
                   city: "Oakland",
                   state: "CA",
@@ -81,25 +81,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|Expected |
+                    actual   %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
+                    plain    %|   to eq |
+                    expected %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "123 Main St.",|
-                  beta_line  %|+   "line_1" => "456 Ponderosa Ct.",|
-                  alpha_line %|-   "city" => "Hill Valley",|
-                  beta_line  %|+   "city" => "Oakland",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "90382"|
-                  beta_line  %|+   "zip" => "91234"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "123 Main St.",|
+                  actual_line   %|+   "line_1" => "456 Ponderosa Ct.",|
+                  expected_line %|-   "city" => "Hill Valley",|
+                  actual_line   %|+   "city" => "Oakland",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "90382"|
+                  actual_line   %|+   "zip" => "91234"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -124,7 +124,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "91234",
                 })
-                actual = {
+                actual   = {
                   line_1: "123 Main St.",
                   city: "Hill Valley",
                   state: "CA",
@@ -139,25 +139,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
+                    plain    %|Expected |
+                    actual   %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|   to eq |
+                    expected %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "456 Ponderosa Ct.",|
-                  beta_line  %|+   "line_1" => "123 Main St.",|
-                  alpha_line %|-   "city" => "Oakland",|
-                  beta_line  %|+   "city" => "Hill Valley",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "91234"|
-                  beta_line  %|+   "zip" => "90382"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "456 Ponderosa Ct.",|
+                  actual_line   %|+   "line_1" => "123 Main St.",|
+                  expected_line %|-   "city" => "Oakland",|
+                  actual_line   %|+   "city" => "Hill Valley",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "91234"|
+                  actual_line   %|+   "zip" => "90382"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -168,7 +168,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
           end
         end
 
-        context "and the actual hash contains string keys" do
+        context "and the actual   hash contains string keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -178,7 +178,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "91234",
                 })
-                actual = {
+                actual   = {
                   "line_1" => "123 Main St.",
                   "city" => "Hill Valley",
                   "state" => "CA",
@@ -193,25 +193,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
+                    plain    %|Expected |
+                    actual   %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|   to eq |
+                    expected %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "456 Ponderosa Ct.",|
-                  beta_line  %|+   "line_1" => "123 Main St.",|
-                  alpha_line %|-   "city" => "Oakland",|
-                  beta_line  %|+   "city" => "Hill Valley",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "91234"|
-                  beta_line  %|+   "zip" => "90382"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "456 Ponderosa Ct.",|
+                  actual_line   %|+   "line_1" => "123 Main St.",|
+                  expected_line %|-   "city" => "Oakland",|
+                  actual_line   %|+   "city" => "Hill Valley",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "91234"|
+                  actual_line   %|+   "zip" => "90382"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -238,7 +238,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                     })
                   ]
                 })
-                actual = {
+                actual   = {
                   shipments: [
                     {
                       estimated_delivery: {
@@ -257,27 +257,27 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ shipments: [{ estimated_delivery: { from: "2019-05-06", to: "2019-05-09" } }] }|
+                    plain    %|Expected |
+                    actual   %|{ shipments: [{ estimated_delivery: { from: "2019-05-06", to: "2019-05-09" } }] }|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
+                    plain    %|   to eq |
+                    expected %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  plain_line %|    "shipments" => [|
-                  plain_line %|      {|
-                  plain_line %|        "estimated_delivery" => {|
-                  plain_line %|          "from" => "2019-05-06",|
-                  alpha_line %|-         "to" => "2019-05-06"|
-                  beta_line  %|+         "to" => "2019-05-09"|
-                  plain_line %|        }|
-                  plain_line %|      }|
-                  plain_line %|    ]|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  plain_line    %|    "shipments" => [|
+                  plain_line    %|      {|
+                  plain_line    %|        "estimated_delivery" => {|
+                  plain_line    %|          "from" => "2019-05-06",|
+                  expected_line %|-         "to" => "2019-05-06"|
+                  actual_line   %|+         "to" => "2019-05-09"|
+                  plain_line    %|        }|
+                  plain_line    %|      }|
+                  plain_line    %|    ]|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -288,7 +288,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
           end
         end
 
-        context "and the actual hash contains string keys" do
+        context "and the actual   hash contains string keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -302,7 +302,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                     })
                   ]
                 })
-                actual = {
+                actual   = {
                   'shipments' => [
                     {
                       'estimated_delivery' => {
@@ -321,27 +321,27 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to eq(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ "shipments" => [{ "estimated_delivery" => { "from" => "2019-05-06", "to" => "2019-05-09" } }] }|
+                    plain    %|Expected |
+                    actual   %|{ "shipments" => [{ "estimated_delivery" => { "from" => "2019-05-06", "to" => "2019-05-09" } }] }|
                   end
 
                   line do
-                    plain "   to eq "
-                    alpha %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
+                    plain    %|   to eq |
+                    expected %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  plain_line %|    "shipments" => [|
-                  plain_line %|      {|
-                  plain_line %|        "estimated_delivery" => {|
-                  plain_line %|          "from" => "2019-05-06",|
-                  alpha_line %|-         "to" => "2019-05-06"|
-                  beta_line  %|+         "to" => "2019-05-09"|
-                  plain_line %|        }|
-                  plain_line %|      }|
-                  plain_line %|    ]|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  plain_line    %|    "shipments" => [|
+                  plain_line    %|      {|
+                  plain_line    %|        "estimated_delivery" => {|
+                  plain_line    %|          "from" => "2019-05-06",|
+                  expected_line %|-         "to" => "2019-05-06"|
+                  actual_line   %|+         "to" => "2019-05-09"|
+                  plain_line    %|        }|
+                  plain_line    %|      }|
+                  plain_line    %|    ]|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -356,7 +356,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
   end
 
   describe "and RSpec's #match matcher" do
-    context "when the actual value is a HashWithIndifferentAccess" do
+    context "when the actual   value is a HashWithIndifferentAccess" do
       context "and both hashes are one-dimensional" do
         context "and the expected hash contains symbol keys" do
           it "produces the correct output" do
@@ -368,7 +368,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "90382",
                 }
-                actual = HashWithIndifferentAccess.new({
+                actual   = HashWithIndifferentAccess.new({
                   line_1: "456 Ponderosa Ct.",
                   city: "Oakland",
                   state: "CA",
@@ -383,25 +383,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|Expected |
+                    actual   %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
+                    plain    %|to match |
+                    expected %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "123 Main St.",|
-                  beta_line  %|+   "line_1" => "456 Ponderosa Ct.",|
-                  alpha_line %|-   "city" => "Hill Valley",|
-                  beta_line  %|+   "city" => "Oakland",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "90382"|
-                  beta_line  %|+   "zip" => "91234"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "123 Main St.",|
+                  actual_line   %|+   "line_1" => "456 Ponderosa Ct.",|
+                  expected_line %|-   "city" => "Hill Valley",|
+                  actual_line   %|+   "city" => "Oakland",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "90382"|
+                  actual_line   %|+   "zip" => "91234"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -422,7 +422,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   "state" => "CA",
                   "zip" => "90382",
                 }
-                actual = HashWithIndifferentAccess.new({
+                actual   = HashWithIndifferentAccess.new({
                   line_1: "456 Ponderosa Ct.",
                   city: "Oakland",
                   state: "CA",
@@ -437,25 +437,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|Expected |
+                    actual   %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
+                    plain    %|to match |
+                    expected %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "123 Main St.",|
-                  beta_line  %|+   "line_1" => "456 Ponderosa Ct.",|
-                  alpha_line %|-   "city" => "Hill Valley",|
-                  beta_line  %|+   "city" => "Oakland",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "90382"|
-                  beta_line  %|+   "zip" => "91234"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "123 Main St.",|
+                  actual_line   %|+   "line_1" => "456 Ponderosa Ct.",|
+                  expected_line %|-   "city" => "Hill Valley",|
+                  actual_line   %|+   "city" => "Oakland",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "90382"|
+                  actual_line   %|+   "zip" => "91234"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -470,7 +470,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
 
     context "when the expected value is a HashWithIndifferentAccess" do
       context "and both hashes are one-dimensional" do
-        context "and the actual hash contains symbol keys" do
+        context "and the actual   hash contains symbol keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -480,7 +480,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "91234",
                 })
-                actual = {
+                actual   = {
                   line_1: "123 Main St.",
                   city: "Hill Valley",
                   state: "CA",
@@ -495,25 +495,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
+                    plain    %|Expected |
+                    actual   %|{ line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" }|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|to match |
+                    expected %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "456 Ponderosa Ct.",|
-                  beta_line  %|+   "line_1" => "123 Main St.",|
-                  alpha_line %|-   "city" => "Oakland",|
-                  beta_line  %|+   "city" => "Hill Valley",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "91234"|
-                  beta_line  %|+   "zip" => "90382"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "456 Ponderosa Ct.",|
+                  actual_line   %|+   "line_1" => "123 Main St.",|
+                  expected_line %|-   "city" => "Oakland",|
+                  actual_line   %|+   "city" => "Hill Valley",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "91234"|
+                  actual_line   %|+   "zip" => "90382"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -524,7 +524,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
           end
         end
 
-        context "and the actual hash contains string keys" do
+        context "and the actual   hash contains string keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -534,7 +534,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                   state: "CA",
                   zip: "91234",
                 })
-                actual = {
+                actual   = {
                   "line_1" => "123 Main St.",
                   "city" => "Hill Valley",
                   "state" => "CA",
@@ -549,25 +549,25 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
+                    plain    %|Expected |
+                    actual   %|{ "line_1" => "123 Main St.", "city" => "Hill Valley", "state" => "CA", "zip" => "90382" }|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
+                    plain    %|to match |
+                    expected %|#<HashWithIndifferentAccess { "line_1" => "456 Ponderosa Ct.", "city" => "Oakland", "state" => "CA", "zip" => "91234" }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  alpha_line %|-   "line_1" => "456 Ponderosa Ct.",|
-                  beta_line  %|+   "line_1" => "123 Main St.",|
-                  alpha_line %|-   "city" => "Oakland",|
-                  beta_line  %|+   "city" => "Hill Valley",|
-                  plain_line %|    "state" => "CA",|
-                  alpha_line %|-   "zip" => "91234"|
-                  beta_line  %|+   "zip" => "90382"|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  expected_line %|-   "line_1" => "456 Ponderosa Ct.",|
+                  actual_line   %|+   "line_1" => "123 Main St.",|
+                  expected_line %|-   "city" => "Oakland",|
+                  actual_line   %|+   "city" => "Hill Valley",|
+                  plain_line    %|    "state" => "CA",|
+                  expected_line %|-   "zip" => "91234"|
+                  actual_line   %|+   "zip" => "90382"|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -580,7 +580,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
       end
 
       context "and both hashes are multi-dimensional" do
-        context "and the actual hash contains symbol keys" do
+        context "and the actual   hash contains symbol keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -594,7 +594,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                     })
                   ]
                 })
-                actual = {
+                actual   = {
                   shipments: [
                     {
                       estimated_delivery: {
@@ -613,27 +613,27 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ shipments: [{ estimated_delivery: { from: "2019-05-06", to: "2019-05-09" } }] }|
+                    plain    %|Expected |
+                    actual   %|{ shipments: [{ estimated_delivery: { from: "2019-05-06", to: "2019-05-09" } }] }|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
+                    plain    %|to match |
+                    expected %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  plain_line %|    "shipments" => [|
-                  plain_line %|      {|
-                  plain_line %|        "estimated_delivery" => {|
-                  plain_line %|          "from" => "2019-05-06",|
-                  alpha_line %|-         "to" => "2019-05-06"|
-                  beta_line  %|+         "to" => "2019-05-09"|
-                  plain_line %|        }|
-                  plain_line %|      }|
-                  plain_line %|    ]|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  plain_line    %|    "shipments" => [|
+                  plain_line    %|      {|
+                  plain_line    %|        "estimated_delivery" => {|
+                  plain_line    %|          "from" => "2019-05-06",|
+                  expected_line %|-         "to" => "2019-05-06"|
+                  actual_line   %|+         "to" => "2019-05-09"|
+                  plain_line    %|        }|
+                  plain_line    %|      }|
+                  plain_line    %|    ]|
+                  plain_line    %|  }>|
                 },
               )
 
@@ -644,7 +644,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
           end
         end
 
-        context "and the actual hash contains string keys" do
+        context "and the actual   hash contains string keys" do
           it "produces the correct output" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -658,7 +658,7 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                     })
                   ]
                 })
-                actual = {
+                actual   = {
                   'shipments' => [
                     {
                       'estimated_delivery' => {
@@ -677,27 +677,27 @@ shared_examples_for "integration with HashWithIndifferentAccess" do
                 snippet: "expect(actual).to match(expected)",
                 expectation: proc {
                   line do
-                    plain "Expected "
-                    beta %|{ "shipments" => [{ "estimated_delivery" => { "from" => "2019-05-06", "to" => "2019-05-09" } }] }|
+                    plain    %|Expected |
+                    actual   %|{ "shipments" => [{ "estimated_delivery" => { "from" => "2019-05-06", "to" => "2019-05-09" } }] }|
                   end
 
                   line do
-                    plain "to match "
-                    alpha %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
+                    plain    %|to match |
+                    expected %|#<HashWithIndifferentAccess { "shipments" => [#<HashWithIndifferentAccess { "estimated_delivery" => #<HashWithIndifferentAccess { "from" => "2019-05-06", "to" => "2019-05-06" }> }>] }>|
                   end
                 },
                 diff: proc {
-                  plain_line %|  #<HashWithIndifferentAccess {|
-                  plain_line %|    "shipments" => [|
-                  plain_line %|      {|
-                  plain_line %|        "estimated_delivery" => {|
-                  plain_line %|          "from" => "2019-05-06",|
-                  alpha_line %|-         "to" => "2019-05-06"|
-                  beta_line  %|+         "to" => "2019-05-09"|
-                  plain_line %|        }|
-                  plain_line %|      }|
-                  plain_line %|    ]|
-                  plain_line %|  }>|
+                  plain_line    %|  #<HashWithIndifferentAccess {|
+                  plain_line    %|    "shipments" => [|
+                  plain_line    %|      {|
+                  plain_line    %|        "estimated_delivery" => {|
+                  plain_line    %|          "from" => "2019-05-06",|
+                  expected_line %|-         "to" => "2019-05-06"|
+                  actual_line   %|+         "to" => "2019-05-09"|
+                  plain_line    %|        }|
+                  plain_line    %|      }|
+                  plain_line    %|    ]|
+                  plain_line    %|  }>|
                 },
               )
 

--- a/spec/unit/equality_matchers/main_spec.rb
+++ b/spec/unit/equality_matchers/main_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: 42)
-              beta_line  %(  Actual: 1)
+              expected_line %(Expected: 42)
+              actual_line   %(  Actual: 1)
             end
           }
         STR
@@ -54,8 +54,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: :foo)
-              beta_line  %(  Actual: :bar)
+              expected_line %(Expected: :foo)
+              actual_line   %(  Actual: :bar)
             end
           }
         STR
@@ -84,8 +84,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "Marty")
-              beta_line  %(  Actual: "Jennifer")
+              expected_line %(Expected: "Marty")
+              actual_line   %(  Actual: "Jennifer")
             end
           }
         STR
@@ -106,8 +106,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "Marty")
-              beta_line  %(  Actual: "Marty McFly")
+              expected_line %(Expected: "Marty")
+              actual_line   %(  Actual: "Marty McFly")
             end
           }
         STR
@@ -128,8 +128,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "Something entirely different")
-              beta_line  %(  Actual: "This is a line\\nAnd that's another line\\n")
+              expected_line %(Expected: "Something entirely different")
+              actual_line   %(  Actual: "This is a line\\nAnd that's another line\\n")
             end
           }
         STR
@@ -150,8 +150,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "This is a line\\nAnd that's another line\\n")
-              beta_line  %(  Actual: "Something entirely different")
+              expected_line %(Expected: "This is a line\\nAnd that's another line\\n")
+              actual_line   %(  Actual: "Something entirely different")
             end
           }
         STR
@@ -172,8 +172,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "This is a line\\nAnd that's a line\\nAnd there's a line too")
-              beta_line  %(  Actual: "This is a line\\nSomething completely different\\nAnd there's a line too")
+              expected_line %(Expected: "This is a line\\nAnd that's a line\\nAnd there's a line too")
+              actual_line   %(  Actual: "This is a line\\nSomething completely different\\nAnd there's a line too")
             end
           }
 
@@ -181,10 +181,10 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  This is a line\\n)
-              alpha_line %(- And that's a line\\n)
-              beta_line  %(+ Something completely different\\n)
-              plain_line %(  And there's a line too)
+              plain_line    %(  This is a line\\n)
+              expected_line %(- And that's a line\\n)
+              actual_line   %(+ Something completely different\\n)
+              plain_line    %(  And there's a line too)
             end
           }
         STR
@@ -205,8 +205,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: "This is a line\\nAnd that's a line\\n")
-              beta_line  %(  Actual: "Something completely different\\nAnd something else too\\n")
+              expected_line %(Expected: "This is a line\\nAnd that's a line\\n")
+              actual_line   %(  Actual: "Something completely different\\nAnd something else too\\n")
             end
           }
 
@@ -214,10 +214,10 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(- This is a line\\n)
-              alpha_line %(- And that's a line\\n)
-              beta_line  %(+ Something completely different\\n)
-              beta_line  %(+ And something else too\\n)
+              expected_line %(- This is a line\\n)
+              expected_line %(- And that's a line\\n)
+              actual_line   %(+ Something completely different\\n)
+              actual_line   %(+ And something else too\\n)
             end
           }
         STR
@@ -264,12 +264,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line do
+              expected_line do
                 text "Expected: "
                 text %("\\e[34mThis is a line\\e[0m\\n\\e[38;5;176mAnd that's a line\\e[0m\\n\\e[38;2;47;59;164mAnd there's a line too\\e[0m\\n")
               end
 
-              beta_line do
+              actual_line   do
                 text "  Actual: "
                 text %("\\e[34mThis is a line\\e[0m\\n\\e[38;5;176mSomething completely different\\e[0m\\n\\e[38;2;47;59;164mAnd there's a line too\\e[0m\\n")
               end
@@ -280,10 +280,10 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  \\e[34mThis is a line\\e[0m\\n)
-              alpha_line %(- \\e[38;5;176mAnd that's a line\\e[0m\\n)
-              beta_line  %(+ \\e[38;5;176mSomething completely different\\e[0m\\n)
-              plain_line %(  \\e[38;2;47;59;164mAnd there's a line too\\e[0m\\n)
+              plain_line    %(  \\e[34mThis is a line\\e[0m\\n)
+              expected_line %(- \\e[38;5;176mAnd that's a line\\e[0m\\n)
+              actual_line   %(+ \\e[38;5;176mSomething completely different\\e[0m\\n)
+              plain_line    %(  \\e[38;2;47;59;164mAnd there's a line too\\e[0m\\n)
             end
           }
         STR
@@ -315,8 +315,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [1, 2, 3, 4])
-              beta_line  %(  Actual: [1, 2, 99, 4])
+              expected_line %(Expected: [1, 2, 3, 4])
+              actual_line   %(  Actual: [1, 2, 99, 4])
             end
           }
 
@@ -324,13 +324,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    1,)
-              plain_line %(    2,)
-              alpha_line %(-   3,)
-              beta_line  %(+   99,)
-              plain_line %(    4)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    1,)
+              plain_line    %(    2,)
+              expected_line %(-   3,)
+              actual_line   %(+   99,)
+              plain_line    %(    4)
+              plain_line    %(  ])
             end
           }
         STR
@@ -351,8 +351,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [:one, :fish, :two, :fish])
-              beta_line  %(  Actual: [:one, :FISH, :two, :fish])
+              expected_line %(Expected: [:one, :fish, :two, :fish])
+              actual_line   %(  Actual: [:one, :FISH, :two, :fish])
             end
           }
 
@@ -360,13 +360,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    :one,)
-              alpha_line %(-   :fish,)
-              beta_line  %(+   :FISH,)
-              plain_line %(    :two,)
-              plain_line %(    :fish)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    :one,)
+              expected_line %(-   :fish,)
+              actual_line   %(+   :FISH,)
+              plain_line    %(    :two,)
+              plain_line    %(    :fish)
+              plain_line    %(  ])
             end
           }
         STR
@@ -387,8 +387,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["sausage", "egg", "cheese"])
-              beta_line  %(  Actual: ["bacon", "egg", "cheese"])
+              expected_line %(Expected: ["sausage", "egg", "cheese"])
+              actual_line   %(  Actual: ["bacon", "egg", "cheese"])
             end
           }
 
@@ -396,12 +396,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              alpha_line %(-   "sausage",)
-              beta_line  %(+   "bacon",)
-              plain_line %(    "egg",)
-              plain_line %(    "cheese")
-              plain_line %(  ])
+              plain_line    %(  [)
+              expected_line %(-   "sausage",)
+              actual_line   %(+   "bacon",)
+              plain_line    %(    "egg",)
+              plain_line    %(    "cheese")
+              plain_line    %(  ])
             end
           }
         STR
@@ -428,8 +428,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [#<SuperDiff::Test::Person name: "Marty", age: 18>, #<SuperDiff::Test::Person name: "Jennifer", age: 17>])
-              beta_line  %(  Actual: [#<SuperDiff::Test::Person name: "Marty", age: 18>, #<SuperDiff::Test::Person name: "Doc", age: 50>])
+              expected_line %(Expected: [#<SuperDiff::Test::Person name: "Marty", age: 18>, #<SuperDiff::Test::Person name: "Jennifer", age: 17>])
+              actual_line   %(  Actual: [#<SuperDiff::Test::Person name: "Marty", age: 18>, #<SuperDiff::Test::Person name: "Doc", age: 50>])
             end
           }
 
@@ -437,18 +437,18 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    #<SuperDiff::Test::Person {)
-              plain_line %(      name: "Marty",)
-              plain_line %(      age: 18)
-              plain_line %(    }>,)
-              plain_line %(    #<SuperDiff::Test::Person {)
-              alpha_line %(-     name: "Jennifer",)
-              beta_line  %(+     name: "Doc",)
-              alpha_line %(-     age: 17)
-              beta_line  %(+     age: 50)
-              plain_line %(    }>)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    #<SuperDiff::Test::Person {)
+              plain_line    %(      name: "Marty",)
+              plain_line    %(      age: 18)
+              plain_line    %(    }>,)
+              plain_line    %(    #<SuperDiff::Test::Person {)
+              expected_line %(-     name: "Jennifer",)
+              actual_line   %(+     name: "Doc",)
+              expected_line %(-     age: 17)
+              actual_line   %(+     age: 50)
+              plain_line    %(    }>)
+              plain_line    %(  ])
             end
           }
         STR
@@ -469,8 +469,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["bread"])
-              beta_line  %(  Actual: ["bread", "eggs", "milk"])
+              expected_line %(Expected: ["bread"])
+              actual_line   %(  Actual: ["bread", "eggs", "milk"])
             end
           }
 
@@ -478,11 +478,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    "bread",)
-              beta_line  %(+   "eggs",)
-              beta_line  %(+   "milk")
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    "bread",)
+              actual_line   %(+   "eggs",)
+              actual_line   %(+   "milk")
+              plain_line    %(  ])
             end
           }
         STR
@@ -503,8 +503,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["bread", "eggs", "milk"])
-              beta_line  %(  Actual: ["bread"])
+              expected_line %(Expected: ["bread", "eggs", "milk"])
+              actual_line   %(  Actual: ["bread"])
             end
           }
 
@@ -512,11 +512,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    "bread")
-              alpha_line %(-   "eggs",)
-              alpha_line %(-   "milk")
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    "bread")
+              expected_line %(-   "eggs",)
+              expected_line %(-   "milk")
+              plain_line    %(  ])
             end
           }
         STR
@@ -537,8 +537,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["milk"])
-              beta_line  %(  Actual: ["bread", "eggs", "milk"])
+              expected_line %(Expected: ["milk"])
+              actual_line   %(  Actual: ["bread", "eggs", "milk"])
             end
           }
 
@@ -546,11 +546,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              beta_line  %(+   "bread",)
-              beta_line  %(+   "eggs",)
-              plain_line %(    "milk")
-              plain_line %(  ])
+              plain_line    %(  [)
+              actual_line   %(+   "bread",)
+              actual_line   %(+   "eggs",)
+              plain_line    %(    "milk")
+              plain_line    %(  ])
             end
           }
         STR
@@ -571,8 +571,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["bread", "eggs", "milk"])
-              beta_line  %(  Actual: ["milk"])
+              expected_line %(Expected: ["bread", "eggs", "milk"])
+              actual_line   %(  Actual: ["milk"])
             end
           }
 
@@ -580,11 +580,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              alpha_line %(-   "bread",)
-              alpha_line %(-   "eggs",)
-              plain_line %(    "milk")
-              plain_line %(  ])
+              plain_line    %(  [)
+              expected_line %(-   "bread",)
+              expected_line %(-   "eggs",)
+              plain_line    %(    "milk")
+              plain_line    %(  ])
             end
           }
         STR
@@ -605,8 +605,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [1, 2, [:a, :b, :c], 4])
-              beta_line  %(  Actual: [1, 2, [:a, :x, :c], 4])
+              expected_line %(Expected: [1, 2, [:a, :b, :c], 4])
+              actual_line   %(  Actual: [1, 2, [:a, :x, :c], 4])
             end
           }
 
@@ -614,17 +614,17 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    1,)
-              plain_line %(    2,)
-              plain_line %(    [)
-              plain_line %(      :a,)
-              alpha_line %(-     :b,)
-              beta_line  %(+     :x,)
-              plain_line %(      :c)
-              plain_line %(    ],)
-              plain_line %(    4)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    1,)
+              plain_line    %(    2,)
+              plain_line    %(    [)
+              plain_line    %(      :a,)
+              expected_line %(-     :b,)
+              actual_line   %(+     :x,)
+              plain_line    %(      :c)
+              plain_line    %(    ],)
+              plain_line    %(    4)
+              plain_line    %(  ])
             end
           }
         STR
@@ -645,8 +645,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [1, 2, { foo: "bar", baz: "qux" }, 4])
-              beta_line  %(  Actual: [1, 2, { foo: "bar", baz: "qox" }, 4])
+              expected_line %(Expected: [1, 2, { foo: "bar", baz: "qux" }, 4])
+              actual_line   %(  Actual: [1, 2, { foo: "bar", baz: "qox" }, 4])
             end
           }
 
@@ -654,16 +654,16 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    1,)
-              plain_line %(    2,)
-              plain_line %(    {)
-              plain_line %(      foo: "bar",)
-              alpha_line %(-     baz: "qux")
-              beta_line  %(+     baz: "qox")
-              plain_line %(    },)
-              plain_line %(    4)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    1,)
+              plain_line    %(    2,)
+              plain_line    %(    {)
+              plain_line    %(      foo: "bar",)
+              expected_line %(-     baz: "qux")
+              actual_line   %(+     baz: "qox")
+              plain_line    %(    },)
+              plain_line    %(    4)
+              plain_line    %(  ])
             end
           }
         STR
@@ -689,8 +689,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [1, 2, #<SuperDiff::Test::Person name: "Marty", age: 18>, 4])
-              beta_line  %(  Actual: [1, 2, #<SuperDiff::Test::Person name: "Doc", age: 50>, 4])
+              expected_line %(Expected: [1, 2, #<SuperDiff::Test::Person name: "Marty", age: 18>, 4])
+              actual_line   %(  Actual: [1, 2, #<SuperDiff::Test::Person name: "Doc", age: 50>, 4])
             end
           }
 
@@ -698,17 +698,17 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    1,)
-              plain_line %(    2,)
-              plain_line %(    #<SuperDiff::Test::Person {)
-              alpha_line %(-     name: "Marty",)
-              beta_line  %(+     name: "Doc",)
-              alpha_line %(-     age: 18)
-              beta_line  %(+     age: 50)
-              plain_line %(    }>,)
-              plain_line %(    4)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    1,)
+              plain_line    %(    2,)
+              plain_line    %(    #<SuperDiff::Test::Person {)
+              expected_line %(-     name: "Marty",)
+              actual_line   %(+     name: "Doc",)
+              expected_line %(-     age: 18)
+              actual_line   %(+     age: 50)
+              plain_line    %(    }>,)
+              plain_line    %(    4)
+              plain_line    %(  ])
             end
           }
         STR
@@ -749,8 +749,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: [[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true } }]])
-              beta_line  %(  Actual: [[:h2, [:span, [:text, "Goodbye world"]], { id: "hero", class: "header", data: { "sticky" => false, :role => "deprecated" } }], :br])
+              expected_line %(Expected: [[:h1, [:span, [:text, "Hello world"]], { class: "header", data: { "sticky" => true } }]])
+              actual_line   %(  Actual: [[:h2, [:span, [:text, "Goodbye world"]], { id: "hero", class: "header", data: { "sticky" => false, :role => "deprecated" } }], :br])
             end
           }
 
@@ -758,30 +758,30 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    [)
-              alpha_line %(-     :h1,)
-              beta_line  %(+     :h2,)
-              plain_line %(      [)
-              plain_line %(        :span,)
-              plain_line %(        [)
-              plain_line %(          :text,)
-              alpha_line %(-         "Hello world")
-              beta_line  %(+         "Goodbye world")
-              plain_line %(        ])
-              plain_line %(      ],)
-              plain_line %(      {)
-              beta_line  %(+       id: "hero",)
-              plain_line %(        class: "header",)
-              plain_line %(        data: {)
-              alpha_line %(-         "sticky" => true)
-              beta_line  %(+         "sticky" => false,)
-              beta_line  %(+         role: "deprecated")
-              plain_line %(        })
-              plain_line %(      })
-              plain_line %(    ],)
-              beta_line  %(+   :br)
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    [)
+              expected_line %(-     :h1,)
+              actual_line   %(+     :h2,)
+              plain_line    %(      [)
+              plain_line    %(        :span,)
+              plain_line    %(        [)
+              plain_line    %(          :text,)
+              expected_line %(-         "Hello world")
+              actual_line   %(+         "Goodbye world")
+              plain_line    %(        ])
+              plain_line    %(      ],)
+              plain_line    %(      {)
+              actual_line   %(+       id: "hero",)
+              plain_line    %(        class: "header",)
+              plain_line    %(        data: {)
+              expected_line %(-         "sticky" => true)
+              actual_line   %(+         "sticky" => false,)
+              actual_line   %(+         role: "deprecated")
+              plain_line    %(        })
+              plain_line    %(      })
+              plain_line    %(    ],)
+              actual_line   %(+   :br)
+              plain_line    %(  ])
             end
           }
         STR
@@ -813,8 +813,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { tall: 12, grande: 19, venti: 20 })
-              beta_line  %(  Actual: { tall: 12, grande: 16, venti: 20 })
+              expected_line %(Expected: { tall: 12, grande: 19, venti: 20 })
+              actual_line   %(  Actual: { tall: 12, grande: 16, venti: 20 })
             end
           }
 
@@ -822,12 +822,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    tall: 12,)
-              alpha_line %(-   grande: 19,)
-              beta_line  %(+   grande: 16,)
-              plain_line %(    venti: 20)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    tall: 12,)
+              expected_line %(-   grande: 19,)
+              actual_line   %(+   grande: 16,)
+              plain_line    %(    venti: 20)
+              plain_line    %(  })
             end
           }
         STR
@@ -848,8 +848,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { "tall" => 12, "grande" => 19, "venti" => 20 })
-              beta_line  %(  Actual: { "tall" => 12, "grande" => 16, "venti" => 20 })
+              expected_line %(Expected: { "tall" => 12, "grande" => 19, "venti" => 20 })
+              actual_line   %(  Actual: { "tall" => 12, "grande" => 16, "venti" => 20 })
             end
           }
 
@@ -857,12 +857,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    "tall" => 12,)
-              alpha_line %(-   "grande" => 19,)
-              beta_line  %(+   "grande" => 16,)
-              plain_line %(    "venti" => 20)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    "tall" => 12,)
+              expected_line %(-   "grande" => 19,)
+              actual_line   %(+   "grande" => 16,)
+              plain_line    %(    "venti" => 20)
+              plain_line    %(  })
             end
           }
         STR
@@ -883,8 +883,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { tall: :small, grande: :grand, venti: :large })
-              beta_line  %(  Actual: { tall: :small, grande: :medium, venti: :large })
+              expected_line %(Expected: { tall: :small, grande: :grand, venti: :large })
+              actual_line   %(  Actual: { tall: :small, grande: :medium, venti: :large })
             end
           }
 
@@ -892,12 +892,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    tall: :small,)
-              alpha_line %(-   grande: :grand,)
-              beta_line  %(+   grande: :medium,)
-              plain_line %(    venti: :large)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    tall: :small,)
+              expected_line %(-   grande: :grand,)
+              actual_line   %(+   grande: :medium,)
+              plain_line    %(    venti: :large)
+              plain_line    %(  })
             end
           }
         STR
@@ -918,8 +918,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { tall: "small", grande: "grand", venti: "large" })
-              beta_line  %(  Actual: { tall: "small", grande: "medium", venti: "large" })
+              expected_line %(Expected: { tall: "small", grande: "grand", venti: "large" })
+              actual_line   %(  Actual: { tall: "small", grande: "medium", venti: "large" })
             end
           }
 
@@ -927,12 +927,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    tall: "small",)
-              alpha_line %(-   grande: "grand",)
-              beta_line  %(+   grande: "medium",)
-              plain_line %(    venti: "large")
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    tall: "small",)
+              expected_line %(-   grande: "grand",)
+              actual_line   %(+   grande: "medium",)
+              plain_line    %(    venti: "large")
+              plain_line    %(  })
             end
           }
         STR
@@ -959,8 +959,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { steve: #<SuperDiff::Test::Person name: "Jobs", age: 30>, susan: #<SuperDiff::Test::Person name: "Kare", age: 27> })
-              beta_line  %(  Actual: { steve: #<SuperDiff::Test::Person name: "Wozniak", age: 33>, susan: #<SuperDiff::Test::Person name: "Kare", age: 27> })
+              expected_line %(Expected: { steve: #<SuperDiff::Test::Person name: "Jobs", age: 30>, susan: #<SuperDiff::Test::Person name: "Kare", age: 27> })
+              actual_line   %(  Actual: { steve: #<SuperDiff::Test::Person name: "Wozniak", age: 33>, susan: #<SuperDiff::Test::Person name: "Kare", age: 27> })
             end
           }
 
@@ -968,18 +968,18 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    steve: #<SuperDiff::Test::Person {)
-              alpha_line %(-     name: "Jobs",)
-              beta_line  %(+     name: "Wozniak",)
-              alpha_line %(-     age: 30)
-              beta_line  %(+     age: 33)
-              plain_line %(    }>,)
-              plain_line %(    susan: #<SuperDiff::Test::Person {)
-              plain_line %(      name: "Kare",)
-              plain_line %(      age: 27)
-              plain_line %(    }>)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    steve: #<SuperDiff::Test::Person {)
+              expected_line %(-     name: "Jobs",)
+              actual_line   %(+     name: "Wozniak",)
+              expected_line %(-     age: 30)
+              actual_line   %(+     age: 33)
+              plain_line    %(    }>,)
+              plain_line    %(    susan: #<SuperDiff::Test::Person {)
+              plain_line    %(      name: "Kare",)
+              plain_line    %(      age: 27)
+              plain_line    %(    }>)
+              plain_line    %(  })
             end
           }
         STR
@@ -1000,8 +1000,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { latte: 4.5 })
-              beta_line  %(  Actual: { latte: 4.5, mocha: 3.5, cortado: 3 })
+              expected_line %(Expected: { latte: 4.5 })
+              actual_line   %(  Actual: { latte: 4.5, mocha: 3.5, cortado: 3 })
             end
           }
 
@@ -1009,11 +1009,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    latte: 4.5,)
-              beta_line  %(+   mocha: 3.5,)
-              beta_line  %(+   cortado: 3)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    latte: 4.5,)
+              actual_line   %(+   mocha: 3.5,)
+              actual_line   %(+   cortado: 3)
+              plain_line    %(  })
             end
           }
         STR
@@ -1034,8 +1034,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { latte: 4.5, mocha: 3.5, cortado: 3 })
-              beta_line  %(  Actual: { latte: 4.5 })
+              expected_line %(Expected: { latte: 4.5, mocha: 3.5, cortado: 3 })
+              actual_line   %(  Actual: { latte: 4.5 })
             end
           }
 
@@ -1043,11 +1043,11 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    latte: 4.5)
-              alpha_line %(-   mocha: 3.5,)
-              alpha_line %(-   cortado: 3)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    latte: 4.5)
+              expected_line %(-   mocha: 3.5,)
+              expected_line %(-   cortado: 3)
+              plain_line    %(  })
             end
           }
         STR
@@ -1099,8 +1099,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
             #{
               colored do
-                alpha_line %(Expected: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, statuses_count: 273860, media_count: 51044, contributors_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
-                beta_line  %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, time_zone: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                expected_line %(Expected: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, statuses_count: 273860, media_count: 51044, contributors_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                actual_line   %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, time_zone: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
               end
             }
 
@@ -1108,26 +1108,26 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
             #{
               colored do
-                plain_line %(  {)
-                plain_line %(    listed_count: 37009,)
-                plain_line %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
-                plain_line %(    favourites_count: 38,)
-                alpha_line %(-   geo_enabled: false,)
-                alpha_line %(-   verified: true,)
-                beta_line  %(+   utc_offset: nil,)
-                beta_line  %(+   time_zone: nil,)
-                plain_line %(    statuses_count: 273860,)
-                plain_line %(    media_count: 51044,)
-                plain_line %(    contributors_enabled: false,)
-                beta_line  %(+   is_translator: false,)
-                beta_line  %(+   is_translation_enabled: false,)
-                plain_line %(    profile_background_color: "FFF1E0",)
-                plain_line %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
-                plain_line %(    profile_background_tile: false,)
-                alpha_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
-                alpha_line %(-   profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
-                plain_line %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
-                plain_line %(  })
+                plain_line    %(  {)
+                plain_line    %(    listed_count: 37009,)
+                plain_line    %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
+                plain_line    %(    favourites_count: 38,)
+                expected_line %(-   geo_enabled: false,)
+                expected_line %(-   verified: true,)
+                actual_line   %(+   utc_offset: nil,)
+                actual_line   %(+   time_zone: nil,)
+                plain_line    %(    statuses_count: 273860,)
+                plain_line    %(    media_count: 51044,)
+                plain_line    %(    contributors_enabled: false,)
+                actual_line   %(+   is_translator: false,)
+                actual_line   %(+   is_translation_enabled: false,)
+                plain_line    %(    profile_background_color: "FFF1E0",)
+                plain_line    %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
+                plain_line    %(    profile_background_tile: false,)
+                expected_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                expected_line %(-   profile_image_url_https: "https://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                plain_line    %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
+                plain_line    %(  })
               end
             }
           STR
@@ -1176,8 +1176,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
             #{
               colored do
-                alpha_line %(Expected: { created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, media_count: 51044, statuses_count: 273860, contributors_enabled: false, profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_color: "FFF1E0", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", listed_count: 37009, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
-                beta_line  %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                expected_line %(Expected: { created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, geo_enabled: false, verified: true, media_count: 51044, statuses_count: 273860, contributors_enabled: false, profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_color: "FFF1E0", profile_background_tile: false, profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg", listed_count: 37009, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
+                actual_line   %(  Actual: { listed_count: 37009, created_at: "Tue Jan 13 19:28:24 +0000 2009", favourites_count: 38, utc_offset: nil, statuses_count: 273860, media_count: 51044, contributors_enabled: false, is_translator: false, is_translation_enabled: false, profile_background_color: "FFF1E0", profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png", profile_background_tile: false, profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592" })
               end
             }
 
@@ -1185,24 +1185,24 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
             #{
               colored do
-                plain_line %(  {)
-                plain_line %(    listed_count: 37009,)
-                plain_line %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
-                plain_line %(    favourites_count: 38,)
-                alpha_line %(-   geo_enabled: false,)
-                alpha_line %(-   verified: true,)
-                beta_line  %(+   utc_offset: nil,)
-                plain_line %(    statuses_count: 273860,)
-                plain_line %(    media_count: 51044,)
-                plain_line %(    contributors_enabled: false,)
-                beta_line  %(+   is_translator: false,)
-                beta_line  %(+   is_translation_enabled: false,)
-                plain_line %(    profile_background_color: "FFF1E0",)
-                plain_line %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
-                plain_line %(    profile_background_tile: false,)
-                alpha_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
-                plain_line %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
-                plain_line %(  })
+                plain_line    %(  {)
+                plain_line    %(    listed_count: 37009,)
+                plain_line    %(    created_at: "Tue Jan 13 19:28:24 +0000 2009",)
+                plain_line    %(    favourites_count: 38,)
+                expected_line %(-   geo_enabled: false,)
+                expected_line %(-   verified: true,)
+                actual_line   %(+   utc_offset: nil,)
+                plain_line    %(    statuses_count: 273860,)
+                plain_line    %(    media_count: 51044,)
+                plain_line    %(    contributors_enabled: false,)
+                actual_line   %(+   is_translator: false,)
+                actual_line   %(+   is_translation_enabled: false,)
+                plain_line    %(    profile_background_color: "FFF1E0",)
+                plain_line    %(    profile_background_image_url_https: "https://abs.twimg.com/images/themes/theme1/bg.png",)
+                plain_line    %(    profile_background_tile: false,)
+                expected_line %(-   profile_image_url: "http://pbs.twimg.com/profile_images/931156393108885504/EqEMtLhM_normal.jpg",)
+                plain_line    %(    profile_banner_url: "https://pbs.twimg.com/profile_banners/18949452/1581526592")
+                plain_line    %(  })
               end
             }
           STR
@@ -1232,8 +1232,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { name: "Elliot", interests: ["music", "football", "programming"], age: 30 })
-              beta_line  %(  Actual: { name: "Elliot", interests: ["music", "travel", "programming"], age: 30 })
+              expected_line %(Expected: { name: "Elliot", interests: ["music", "football", "programming"], age: 30 })
+              actual_line   %(  Actual: { name: "Elliot", interests: ["music", "travel", "programming"], age: 30 })
             end
           }
 
@@ -1241,16 +1241,16 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    name: "Elliot",)
-              plain_line %(    interests: [)
-              plain_line %(      "music",)
-              alpha_line %(-     "football",)
-              beta_line  %(+     "travel",)
-              plain_line %(      "programming")
-              plain_line %(    ],)
-              plain_line %(    age: 30)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    name: "Elliot",)
+              plain_line    %(    interests: [)
+              plain_line    %(      "music",)
+              expected_line %(-     "football",)
+              actual_line   %(+     "travel",)
+              plain_line    %(      "programming")
+              plain_line    %(    ],)
+              plain_line    %(    age: 30)
+              plain_line    %(  })
             end
           }
         STR
@@ -1287,8 +1287,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { check_spelling: true, substitutions: { "YOLO" => "You only live once", "BRB" => "Buns, ribs, and bacon", "YMMV" => "Your mileage may vary" }, check_grammar: false })
-              beta_line  %(  Actual: { check_spelling: true, substitutions: { "YOLO" => "You only live once", "BRB" => "Be right back", "YMMV" => "Your mileage may vary" }, check_grammar: false })
+              expected_line %(Expected: { check_spelling: true, substitutions: { "YOLO" => "You only live once", "BRB" => "Buns, ribs, and bacon", "YMMV" => "Your mileage may vary" }, check_grammar: false })
+              actual_line   %(  Actual: { check_spelling: true, substitutions: { "YOLO" => "You only live once", "BRB" => "Be right back", "YMMV" => "Your mileage may vary" }, check_grammar: false })
             end
           }
 
@@ -1296,16 +1296,16 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    check_spelling: true,)
-              plain_line %(    substitutions: {)
-              plain_line %(      "YOLO" => "You only live once",)
-              alpha_line %(-     "BRB" => "Buns, ribs, and bacon",)
-              beta_line  %(+     "BRB" => "Be right back",)
-              plain_line %(      "YMMV" => "Your mileage may vary")
-              plain_line %(    },)
-              plain_line %(    check_grammar: false)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    check_spelling: true,)
+              plain_line    %(    substitutions: {)
+              plain_line    %(      "YOLO" => "You only live once",)
+              expected_line %(-     "BRB" => "Buns, ribs, and bacon",)
+              actual_line   %(+     "BRB" => "Be right back",)
+              plain_line    %(      "YMMV" => "Your mileage may vary")
+              plain_line    %(    },)
+              plain_line    %(    check_grammar: false)
+              plain_line    %(  })
             end
           }
         STR
@@ -1334,8 +1334,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { order_id: 1234, person: #<SuperDiff::Test::Person name: "Marty", age: 18>, amount: 35000 })
-              beta_line  %(  Actual: { order_id: 1234, person: #<SuperDiff::Test::Person name: "Doc", age: 50>, amount: 35000 })
+              expected_line %(Expected: { order_id: 1234, person: #<SuperDiff::Test::Person name: "Marty", age: 18>, amount: 35000 })
+              actual_line   %(  Actual: { order_id: 1234, person: #<SuperDiff::Test::Person name: "Doc", age: 50>, amount: 35000 })
             end
           }
 
@@ -1343,16 +1343,16 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    order_id: 1234,)
-              plain_line %(    person: #<SuperDiff::Test::Person {)
-              alpha_line %(-     name: "Marty",)
-              beta_line  %(+     name: "Doc",)
-              alpha_line %(-     age: 18)
-              beta_line  %(+     age: 50)
-              plain_line %(    }>,)
-              plain_line %(    amount: 35000)
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    order_id: 1234,)
+              plain_line    %(    person: #<SuperDiff::Test::Person {)
+              expected_line %(-     name: "Marty",)
+              actual_line   %(+     name: "Doc",)
+              expected_line %(-     age: 18)
+              actual_line   %(+     age: 50)
+              plain_line    %(    }>,)
+              plain_line    %(    amount: 35000)
+              plain_line    %(  })
             end
           }
         STR
@@ -1409,8 +1409,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { customer: { name: "Marty McFly", shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] })
-              beta_line  %(  Actual: { customer: { name: "Marty McFly, Jr.", shipping_address: { line_1: "456 Ponderosa Ct.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Mattel Hoverboard" }] })
+              expected_line %(Expected: { customer: { name: "Marty McFly", shipping_address: { line_1: "123 Main St.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Chevy 4x4" }] })
+              actual_line   %(  Actual: { customer: { name: "Marty McFly, Jr.", shipping_address: { line_1: "456 Ponderosa Ct.", city: "Hill Valley", state: "CA", zip: "90382" } }, items: [{ name: "Fender Stratocaster", cost: 100000, options: ["red", "blue", "green"] }, { name: "Mattel Hoverboard" }] })
             end
           }
 
@@ -1418,34 +1418,34 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    customer: {)
-              alpha_line %(-     name: "Marty McFly",)
-              beta_line  %(+     name: "Marty McFly, Jr.",)
-              plain_line %(      shipping_address: {)
-              alpha_line %(-       line_1: "123 Main St.",)
-              beta_line  %(+       line_1: "456 Ponderosa Ct.",)
-              plain_line %(        city: "Hill Valley",)
-              plain_line %(        state: "CA",)
-              plain_line %(        zip: "90382")
-              plain_line %(      })
-              plain_line %(    },)
-              plain_line %(    items: [)
-              plain_line %(      {)
-              plain_line %(        name: "Fender Stratocaster",)
-              plain_line %(        cost: 100000,)
-              plain_line %(        options: [)
-              plain_line %(          "red",)
-              plain_line %(          "blue",)
-              plain_line %(          "green")
-              plain_line %(        ])
-              plain_line %(      },)
-              plain_line %(      {)
-              alpha_line %(-       name: "Chevy 4x4")
-              beta_line  %(+       name: "Mattel Hoverboard")
-              plain_line %(      })
-              plain_line %(    ])
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    customer: {)
+              expected_line %(-     name: "Marty McFly",)
+              actual_line   %(+     name: "Marty McFly, Jr.",)
+              plain_line    %(      shipping_address: {)
+              expected_line %(-       line_1: "123 Main St.",)
+              actual_line   %(+       line_1: "456 Ponderosa Ct.",)
+              plain_line    %(        city: "Hill Valley",)
+              plain_line    %(        state: "CA",)
+              plain_line    %(        zip: "90382")
+              plain_line    %(      })
+              plain_line    %(    },)
+              plain_line    %(    items: [)
+              plain_line    %(      {)
+              plain_line    %(        name: "Fender Stratocaster",)
+              plain_line    %(        cost: 100000,)
+              plain_line    %(        options: [)
+              plain_line    %(          "red",)
+              plain_line    %(          "blue",)
+              plain_line    %(          "green")
+              plain_line    %(        ])
+              plain_line    %(      },)
+              plain_line    %(      {)
+              expected_line %(-       name: "Chevy 4x4")
+              actual_line   %(+       name: "Mattel Hoverboard")
+              plain_line    %(      })
+              plain_line    %(    ])
+              plain_line    %(  })
             end
           }
         STR
@@ -1480,8 +1480,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: #<SuperDiff::Test::Person name: "Marty", age: 18>)
-              beta_line  %(  Actual: #<SuperDiff::Test::Person name: "Doc", age: 50>)
+              expected_line %(Expected: #<SuperDiff::Test::Person name: "Marty", age: 18>)
+              actual_line   %(  Actual: #<SuperDiff::Test::Person name: "Doc", age: 50>)
             end
           }
 
@@ -1489,12 +1489,12 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  #<SuperDiff::Test::Person {)
-              alpha_line %(-   name: "Marty",)
-              beta_line  %(+   name: "Doc",)
-              alpha_line %(-   age: 18)
-              beta_line  %(+   age: 50)
-              plain_line %(  }>)
+              plain_line    %(  #<SuperDiff::Test::Person {)
+              expected_line %(-   name: "Marty",)
+              actual_line   %(+   name: "Doc",)
+              expected_line %(-   age: 18)
+              actual_line   %(+   age: 50)
+              plain_line    %(  }>)
             end
           }
         STR
@@ -1531,13 +1531,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
             if SuperDiff::Test.jruby?
               # Source: <https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/RubyBasicObject.java>
               colored do
-                alpha_line %(Expected: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(expected)} @inventory=["flatline", "purple body shield"], @character="mirage", @handle="martymcfly", @ultimate=0.8, @shields=0.6, @health=0.3>)
-                beta_line  %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @inventory=["wingman", "mastiff"], @character="lifeline", @handle="docbrown", @ultimate=0.8, @shields=0.6, @health=0.3>)
+                expected_line %(Expected: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(expected)} @inventory=["flatline", "purple body shield"], @character="mirage", @handle="martymcfly", @ultimate=0.8, @shields=0.6, @health=0.3>)
+                actual_line   %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @inventory=["wingman", "mastiff"], @character="lifeline", @handle="docbrown", @ultimate=0.8, @shields=0.6, @health=0.3>)
               end
             else
               colored do
-                alpha_line %(Expected: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(expected)} @handle="martymcfly", @character="mirage", @inventory=["flatline", "purple body shield"], @shields=0.6, @health=0.3, @ultimate=0.8>)
-                beta_line  %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @handle="docbrown", @character="lifeline", @inventory=["wingman", "mastiff"], @shields=0.6, @health=0.3, @ultimate=0.8>)
+                expected_line %(Expected: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(expected)} @handle="martymcfly", @character="mirage", @inventory=["flatline", "purple body shield"], @shields=0.6, @health=0.3, @ultimate=0.8>)
+                actual_line   %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @handle="docbrown", @character="lifeline", @inventory=["wingman", "mastiff"], @shields=0.6, @health=0.3, @ultimate=0.8>)
               end
             end
           }
@@ -1546,21 +1546,21 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  #<SuperDiff::Test::Player {)
-              alpha_line %(-   @character="mirage",)
-              beta_line  %(+   @character="lifeline",)
-              alpha_line %(-   @handle="martymcfly",)
-              beta_line  %(+   @handle="docbrown",)
-              plain_line %(    @health=0.3,)
-              plain_line %(    @inventory=[)
-              alpha_line %(-     "flatline",)
-              beta_line  %(+     "wingman",)
-              alpha_line %(-     "purple body shield")
-              beta_line  %(+     "mastiff")
-              plain_line %(    ],)
-              plain_line %(    @shields=0.6,)
-              plain_line %(    @ultimate=0.8)
-              plain_line %(  }>)
+              plain_line    %(  #<SuperDiff::Test::Player {)
+              expected_line %(-   @character="mirage",)
+              actual_line   %(+   @character="lifeline",)
+              expected_line %(-   @handle="martymcfly",)
+              actual_line   %(+   @handle="docbrown",)
+              plain_line    %(    @health=0.3,)
+              plain_line    %(    @inventory=[)
+              expected_line %(-     "flatline",)
+              actual_line   %(+     "wingman",)
+              expected_line %(-     "purple body shield")
+              actual_line   %(+     "mastiff")
+              plain_line    %(    ],)
+              plain_line    %(    @shields=0.6,)
+              plain_line    %(    @ultimate=0.8)
+              plain_line    %(  }>)
             end
           }
         STR
@@ -1588,8 +1588,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: #<SuperDiff::Test::Person name: "Marty", age: 31>)
-              beta_line  %(  Actual: #<SuperDiff::Test::Customer name: "Doc", shipping_address: :some_shipping_address, phone: "1234567890">)
+              expected_line %(Expected: #<SuperDiff::Test::Person name: "Marty", age: 31>)
+              actual_line   %(  Actual: #<SuperDiff::Test::Customer name: "Doc", shipping_address: :some_shipping_address, phone: "1234567890">)
             end
           }
         STR
@@ -1622,13 +1622,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
             if SuperDiff::Test.jruby?
               # Source: <https://github.com/jruby/jruby/blob/master/core/src/main/java/org/jruby/RubyBasicObject.java>
               colored do
-                alpha_line %(Expected: #<SuperDiff::Test::Item:#{SuperDiff::Test.object_id_hex(expected)} @name="camera", @quantity=3>)
-                beta_line  %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @inventory=["sword"], @character="Jon", @handle="mcmire", @ultimate=true, @shields=11.4, @health=4>)
+                expected_line %(Expected: #<SuperDiff::Test::Item:#{SuperDiff::Test.object_id_hex(expected)} @name="camera", @quantity=3>)
+                actual_line   %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @inventory=["sword"], @character="Jon", @handle="mcmire", @ultimate=true, @shields=11.4, @health=4>)
               end
             else
               colored do
-                alpha_line %(Expected: #<SuperDiff::Test::Item:#{SuperDiff::Test.object_id_hex(expected)} @name="camera", @quantity=3>)
-                beta_line  %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @handle="mcmire", @character="Jon", @inventory=["sword"], @shields=11.4, @health=4, @ultimate=true>)
+                expected_line %(Expected: #<SuperDiff::Test::Item:#{SuperDiff::Test.object_id_hex(expected)} @name="camera", @quantity=3>)
+                actual_line   %(  Actual: #<SuperDiff::Test::Player:#{SuperDiff::Test.object_id_hex(actual)} @handle="mcmire", @character="Jon", @inventory=["sword"], @shields=11.4, @health=4, @ultimate=true>)
               end
             end
           }
@@ -1651,8 +1651,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["a", ∙∙∙, "b", "c"])
-              beta_line  %(  Actual: ["a", "x", "b", "c"])
+              expected_line %(Expected: ["a", ∙∙∙, "b", "c"])
+              actual_line   %(  Actual: ["a", "x", "b", "c"])
             end
           }
 
@@ -1660,13 +1660,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    "a",)
-              alpha_line %(-   ∙∙∙,)
-              beta_line  %(+   "x",)
-              plain_line %(    "b",)
-              plain_line %(    "c")
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    "a",)
+              expected_line %(-   ∙∙∙,)
+              actual_line   %(+   "x",)
+              plain_line    %(    "b",)
+              plain_line    %(    "c")
+              plain_line    %(  ])
             end
           }
         STR
@@ -1688,8 +1688,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: ["a", "x", "b", "c"])
-              beta_line  %(  Actual: ["a", ∙∙∙, "b", "c"])
+              expected_line %(Expected: ["a", "x", "b", "c"])
+              actual_line   %(  Actual: ["a", ∙∙∙, "b", "c"])
             end
           }
 
@@ -1697,13 +1697,13 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  [)
-              plain_line %(    "a",)
-              alpha_line %(-   "x",)
-              beta_line  %(+   ∙∙∙,)
-              plain_line %(    "b",)
-              plain_line %(    "c")
-              plain_line %(  ])
+              plain_line    %(  [)
+              plain_line    %(    "a",)
+              expected_line %(-   "x",)
+              actual_line   %(+   ∙∙∙,)
+              plain_line    %(    "b",)
+              plain_line    %(    "c")
+              plain_line    %(  ])
             end
           }
         STR
@@ -1725,8 +1725,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { foo: ["a", "x", "b", "c"] })
-              beta_line  %(  Actual: { foo: ["a", ∙∙∙, "b", "c"] })
+              expected_line %(Expected: { foo: ["a", "x", "b", "c"] })
+              actual_line   %(  Actual: { foo: ["a", ∙∙∙, "b", "c"] })
             end
           }
 
@@ -1734,15 +1734,15 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    foo: [)
-              plain_line %(      "a",)
-              alpha_line %(-     "x",)
-              beta_line  %(+     ∙∙∙,)
-              plain_line %(      "b",)
-              plain_line %(      "c")
-              plain_line %(    ])
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    foo: [)
+              plain_line    %(      "a",)
+              expected_line %(-     "x",)
+              actual_line   %(+     ∙∙∙,)
+              plain_line    %(      "b",)
+              plain_line    %(      "c")
+              plain_line    %(    ])
+              plain_line    %(  })
             end
           }
         STR
@@ -1764,8 +1764,8 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              alpha_line %(Expected: { foo: ["a", "x", "b", "c"] })
-              beta_line  %(  Actual: { foo: ["a", ∙∙∙, "b", "c"] })
+              expected_line %(Expected: { foo: ["a", "x", "b", "c"] })
+              actual_line   %(  Actual: { foo: ["a", ∙∙∙, "b", "c"] })
             end
           }
 
@@ -1773,15 +1773,15 @@ RSpec.describe SuperDiff::EqualityMatchers::Main do
 
           #{
             colored do
-              plain_line %(  {)
-              plain_line %(    foo: [)
-              plain_line %(      "a",)
-              alpha_line %(-     "x",)
-              beta_line  %(+     ∙∙∙,)
-              plain_line %(      "b",)
-              plain_line %(      "c")
-              plain_line %(    ])
-              plain_line %(  })
+              plain_line    %(  {)
+              plain_line    %(    foo: [)
+              plain_line    %(      "a",)
+              expected_line %(-     "x",)
+              actual_line   %(+     ∙∙∙,)
+              plain_line    %(      "b",)
+              plain_line    %(      "c")
+              plain_line    %(    ])
+              plain_line    %(  })
             end
           }
         STR


### PR DESCRIPTION
* Use `attr_accessor`s instead of `set_` methods to prepare for upcoming
  elision settings
* Rename all instances of `alpha` to `expected` and `beta` to `actual`
  across the tests and code
* Adjust alignment in places in tests where colors are used so they're
  easier to read