### PR TITLE
Remove warnings

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -36,27 +36,31 @@ appraisals = {
   rspec_lt_3_10: proc { |with_rails|
     version = "< 3.10"
 
+    gem "rspec", version
+
     if with_rails
-      gem "rspec-core", version
-      gem "rspec-expectations", version
-      gem "rspec-mocks", version
-      gem "rspec-support", version
+      # gem "rspec-core", version
+      # gem "rspec-expectations", version
+      # gem "rspec-mocks", version
+      # gem "rspec-support", version
       gem "rspec-rails"
-    else
-      gem "rspec", version
+    # else
+      # gem "rspec", version
     end
   },
   rspec_gte_3_10: proc { |with_rails|
     version = [">= 3.10", "< 4"]
 
+    gem "rspec", *version
+
     if with_rails
-      gem "rspec-core", *version
-      gem "rspec-expectations", *version
-      gem "rspec-mocks", *version
-      gem "rspec-support", *version
+      # gem "rspec-core", *version
+      # gem "rspec-expectations", *version
+      # gem "rspec-mocks", *version
+      # gem "rspec-support", *version
       gem "rspec-rails"
-    else
-      gem "rspec", *version
+    # else
+      # gem "rspec", *version
     end
   },
 }

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,6 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,9 @@ require_relative "support/current_bundle"
 
 begin
   require "rspec/core/rake_task"
-  RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(spec: :before_spec) do |config|
+    config.verbose = true
+  end
 rescue LoadError
   task :spec do
     appraisal = SuperDiff::CurrentBundle.instance.latest_appraisal
@@ -21,4 +23,8 @@ task :default do
     appraisal = SuperDiff::CurrentBundle.instance.latest_appraisal
     exec "appraisal #{appraisal.name} rake --trace"
   end
+end
+
+task :before_spec do
+  FileUtils.rm_rf(File.expand_path("./spec/tmp", __dir__))
 end

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ begin
 rescue LoadError
   task :spec do
     appraisal = SuperDiff::CurrentBundle.instance.latest_appraisal
-    exec "appraisal install && appraisal #{appraisal.name} rake spec --trace"
+    exec "appraisal #{appraisal.name} rake spec --trace"
   end
 end
 
@@ -16,9 +16,9 @@ task :default do
   if SuperDiff::CurrentBundle.instance.appraisal_in_use?
     sh "rake spec"
   elsif ENV["CI"]
-    exec "appraisal install && appraisal rake --trace"
+    exec "appraisal rake --trace"
   else
     appraisal = SuperDiff::CurrentBundle.instance.latest_appraisal
-    exec "appraisal install && appraisal #{appraisal.name} rake --trace"
+    exec "appraisal #{appraisal.name} rake --trace"
   end
 end

--- a/bin/ci/install
+++ b/bin/ci/install
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+echo $PWD
 bundle config set path $PWD/vendor/bundle
 bundle install --jobs=3 --retry=3

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "rspec", ">= 3.10", "< 4"
 
 gemspec path: "../"

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
@@ -63,6 +63,7 @@ GEM
     thor (1.0.1)
     trollop (1.16.2)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -76,6 +77,7 @@ DEPENDENCIES
   rspec (>= 3.10, < 4)
   rubocop
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "rspec", "< 3.10"
 
 gemspec path: "../"

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
@@ -63,6 +63,7 @@ GEM
     thor (1.0.1)
     trollop (1.16.2)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -76,6 +77,7 @@ DEPENDENCIES
   rspec (< 3.10)
   rubocop
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", ">= 3.10", "< 4"
-gem "rspec-expectations", ">= 3.10", "< 4"
-gem "rspec-mocks", ">= 3.10", "< 4"
-gem "rspec-support", ">= 3.10", "< 4"
+gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.0.0"

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.0.0)
   rake
-  rspec-core (>= 3.10, < 4)
-  rspec-expectations (>= 3.10, < 4)
-  rspec-mocks (>= 3.10, < 4)
+  rspec (>= 3.10, < 4)
   rspec-rails
-  rspec-support (>= 3.10, < 4)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", "< 3.10"
-gem "rspec-expectations", "< 3.10"
-gem "rspec-mocks", "< 3.10"
-gem "rspec-support", "< 3.10"
+gem "rspec", "< 3.10"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.0.0"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.0.0)
   rake
-  rspec-core (< 3.10)
-  rspec-expectations (< 3.10)
-  rspec-mocks (< 3.10)
+  rspec (< 3.10)
   rspec-rails
-  rspec-support (< 3.10)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.1.0"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", ">= 3.10", "< 4"
-gem "rspec-expectations", ">= 3.10", "< 4"
-gem "rspec-mocks", ">= 3.10", "< 4"
-gem "rspec-support", ">= 3.10", "< 4"
+gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.1.0)
   rake
-  rspec-core (>= 3.10, < 4)
-  rspec-expectations (>= 3.10, < 4)
-  rspec-mocks (>= 3.10, < 4)
+  rspec (>= 3.10, < 4)
   rspec-rails
-  rspec-support (>= 3.10, < 4)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", "< 3.10"
-gem "rspec-expectations", "< 3.10"
-gem "rspec-mocks", "< 3.10"
-gem "rspec-support", "< 3.10"
+gem "rspec", "< 3.10"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.1.0"

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.1.0)
   rake
-  rspec-core (< 3.10)
-  rspec-expectations (< 3.10)
-  rspec-mocks (< 3.10)
+  rspec (< 3.10)
   rspec-rails
-  rspec-support (< 3.10)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", ">= 3.10", "< 4"
-gem "rspec-expectations", ">= 3.10", "< 4"
-gem "rspec-mocks", ">= 3.10", "< 4"
-gem "rspec-support", ">= 3.10", "< 4"
+gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.2.0"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.2.0)
   rake
-  rspec-core (>= 3.10, < 4)
-  rspec-expectations (>= 3.10, < 4)
-  rspec-mocks (>= 3.10, < 4)
+  rspec (>= 3.10, < 4)
   rspec-rails
-  rspec-support (>= 3.10, < 4)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.2.0"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", "< 3.10"
-gem "rspec-expectations", "< 3.10"
-gem "rspec-mocks", "< 3.10"
-gem "rspec-support", "< 3.10"
+gem "rspec", "< 3.10"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
@@ -127,6 +127,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
 
 PLATFORMS
   ruby
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
@@ -87,6 +87,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 5.2.0)
   rake
-  rspec-core (< 3.10)
-  rspec-expectations (< 3.10)
-  rspec-mocks (< 3.10)
+  rspec (< 3.10)
   rspec-rails
-  rspec-support (< 3.10)
   rubocop
   sqlite3 (~> 1.3.6)
   super_diff!

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", ">= 3.10", "< 4"
-gem "rspec-expectations", ">= 3.10", "< 4"
-gem "rspec-mocks", ">= 3.10", "< 4"
-gem "rspec-support", ">= 3.10", "< 4"
+gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 6.0"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -86,6 +86,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
     rspec-core (3.10.0)
       rspec-support (~> 3.10.0)
     rspec-expectations (3.10.0)
@@ -137,11 +141,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 6.0)
   rake
-  rspec-core (>= 3.10, < 4)
-  rspec-expectations (>= 3.10, < 4)
-  rspec-mocks (>= 3.10, < 4)
+  rspec (>= 3.10, < 4)
   rspec-rails
-  rspec-support (>= 3.10, < 4)
   rubocop
   sqlite3 (~> 1.4.0)
   super_diff!

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -126,6 +126,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
     zeitwerk (2.4.1)
 
 PLATFORMS
@@ -146,6 +147,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.4.0)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -13,10 +13,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
-gem "rspec-core", "< 3.10"
-gem "rspec-expectations", "< 3.10"
-gem "rspec-mocks", "< 3.10"
-gem "rspec-support", "< 3.10"
+gem "rspec", "< 3.10"
 gem "rspec-rails"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -8,6 +8,7 @@ gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"
 gem "rubocop"
+gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "activerecord", "~> 6.0"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -128,6 +128,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
+    warnings_logger (0.1.1)
     zeitwerk (2.4.1)
 
 PLATFORMS
@@ -148,6 +149,7 @@ DEPENDENCIES
   rubocop
   sqlite3 (~> 1.4.0)
   super_diff!
+  warnings_logger
 
 BUNDLED WITH
    2.1.4

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -88,6 +88,10 @@ GEM
     rake (13.0.1)
     regexp_parser (1.7.1)
     rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)
@@ -139,11 +143,8 @@ DEPENDENCIES
   pry-nav
   railties (~> 6.0)
   rake
-  rspec-core (< 3.10)
-  rspec-expectations (< 3.10)
-  rspec-mocks (< 3.10)
+  rspec (< 3.10)
   rspec-rails
-  rspec-support (< 3.10)
   rubocop
   sqlite3 (~> 1.4.0)
   super_diff!

--- a/lib/super_diff.rb
+++ b/lib/super_diff.rb
@@ -44,4 +44,20 @@ module SuperDiff
     (value.respond_to?(:acts_like_time?) && value.acts_like_time?) ||
       value.is_a?(Time)
   end
+
+  def self.insert_overrides(target_module, mod = nil, &block)
+    if mod
+      target_module.prepend(mod)
+    else
+      target_module.prepend(Module.new(&block))
+    end
+  end
+
+  def self.insert_singleton_overrides(target_module, mod = nil, &block)
+    if mod
+      target_module.singleton_class.prepend(mod)
+    else
+      target_module.singleton_class.prepend(Module.new(&block))
+    end
+  end
 end

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -12,34 +12,38 @@ require "rspec/matchers/built_in/match"
 
 module RSpec
   module Expectations
-    def self.differ
-      SuperDiff::RSpec::Differ
+    SuperDiff.insert_singleton_overrides(self) do
+      def differ
+        SuperDiff::RSpec::Differ
+      end
     end
 
     module ExpectationHelper
-      def self.handle_failure(matcher, message, failure_message_method)
-        message = message.call if message.respond_to?(:call)
-        message ||= matcher.__send__(failure_message_method)
+      SuperDiff.insert_singleton_overrides(self) do
+        def handle_failure(matcher, message, failure_message_method)
+          message = message.call if message.respond_to?(:call)
+          message ||= matcher.__send__(failure_message_method)
 
-        if matcher.respond_to?(:diffable?) && matcher.diffable?
-          # Look for expected_for_diff and actual_for_diff if possible
-          expected =
-            if matcher.respond_to?(:expected_for_diff)
-              matcher.expected_for_diff
-            else
-              matcher.expected
-            end
+          if matcher.respond_to?(:diffable?) && matcher.diffable?
+            # Look for expected_for_diff and actual_for_diff if possible
+            expected =
+              if matcher.respond_to?(:expected_for_diff)
+                matcher.expected_for_diff
+              else
+                matcher.expected
+              end
 
-          actual =
-            if matcher.respond_to?(:actual_for_diff)
-              matcher.actual_for_diff
-            else
-              matcher.actual
-            end
+            actual =
+              if matcher.respond_to?(:actual_for_diff)
+                matcher.actual_for_diff
+              else
+                matcher.actual
+              end
 
-          ::RSpec::Expectations.fail_with(message, expected, actual)
-        else
-          ::RSpec::Expectations.fail_with(message)
+            ::RSpec::Expectations.fail_with(message, expected, actual)
+          else
+            ::RSpec::Expectations.fail_with(message)
+          end
         end
       end
     end
@@ -48,29 +52,31 @@ module RSpec
   module Core
     module Formatters
       module ConsoleCodes
-        # Patch so it returns nothing if code_or_symbol is nil, and that it uses
-        # code_or_symbol if it can't be found in VT100_CODE_VALUES to allow for
-        # customization
-        def self.console_code_for(code_or_symbol)
-          if code_or_symbol
-            if (config_method = config_colors_to_methods[code_or_symbol])
-              console_code_for RSpec.configuration.__send__(config_method)
-            elsif RSpec::Core::Formatters::ConsoleCodes::VT100_CODE_VALUES.key?(code_or_symbol)
-              code_or_symbol
-            else
-              RSpec::Core::Formatters::ConsoleCodes::VT100_CODES.fetch(code_or_symbol) do
+        SuperDiff.insert_singleton_overrides(self) do
+          # Patch so it returns nothing if code_or_symbol is nil, and that it uses
+          # code_or_symbol if it can't be found in VT100_CODE_VALUES to allow for
+          # customization
+          def console_code_for(code_or_symbol)
+            if code_or_symbol
+              if (config_method = config_colors_to_methods[code_or_symbol])
+                console_code_for RSpec.configuration.__send__(config_method)
+              elsif RSpec::Core::Formatters::ConsoleCodes::VT100_CODE_VALUES.key?(code_or_symbol)
                 code_or_symbol
+              else
+                RSpec::Core::Formatters::ConsoleCodes::VT100_CODES.fetch(code_or_symbol) do
+                  code_or_symbol
+                end
               end
             end
           end
-        end
 
-        # Patch so it does not apply a color if code_or_symbol is nil
-        def self.wrap(text, code_or_symbol)
-          if RSpec.configuration.color_enabled? && code = console_code_for(code_or_symbol)
-            "\e[#{code}m#{text}\e[0m"
-          else
-            text
+          # Patch so it does not apply a color if code_or_symbol is nil
+          def wrap(text, code_or_symbol)
+            if RSpec.configuration.color_enabled? && code = console_code_for(code_or_symbol)
+              "\e[#{code}m#{text}\e[0m"
+            else
+              text
+            end
           end
         end
       end
@@ -79,173 +85,177 @@ module RSpec
         # UPDATE: Copy from SyntaxHighlighter::CodeRayImplementation
         RESET_CODE = "\e[0m"
 
-        def initialize(exception, example, options={})
-          @exception               = exception
-          @example                 = example
-          @message_color           = options.fetch(:message_color)          { RSpec.configuration.failure_color }
-          @description             = options.fetch(:description)            { example.full_description }
-          @detail_formatter        = options.fetch(:detail_formatter)       { Proc.new {} }
-          @extra_detail_formatter  = options.fetch(:extra_detail_formatter) { Proc.new {} }
-          @backtrace_formatter     = options.fetch(:backtrace_formatter)    { RSpec.configuration.backtrace_formatter }
-          @indentation             = options.fetch(:indentation, 2)
-          @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
-          # Patch to convert options[:failure_lines] to groups
-          if options.include?(:failure_lines)
-            @failure_line_groups = [
-              {
-                lines: options[:failure_lines],
-                already_colorized: false
-              }
-            ]
+        SuperDiff.insert_overrides(self) do
+          def initialize(exception, example, options={})
+            @exception               = exception
+            @example                 = example
+            @message_color           = options.fetch(:message_color)          { RSpec.configuration.failure_color }
+            @description             = options.fetch(:description)            { example.full_description }
+            @detail_formatter        = options.fetch(:detail_formatter)       { Proc.new {} }
+            @extra_detail_formatter  = options.fetch(:extra_detail_formatter) { Proc.new {} }
+            @backtrace_formatter     = options.fetch(:backtrace_formatter)    { RSpec.configuration.backtrace_formatter }
+            @indentation             = options.fetch(:indentation, 2)
+            @skip_shared_group_trace = options.fetch(:skip_shared_group_trace, false)
+            # Patch to convert options[:failure_lines] to groups
+            if options.include?(:failure_lines)
+              @failure_line_groups = [
+                {
+                  lines: options[:failure_lines],
+                  already_colorized: false
+                }
+              ]
+            end
           end
-        end
 
-        # Override to only color uncolored lines in red
-        # and to not color empty lines
-        def colorized_message_lines(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
-          lines = failure_line_groups.flat_map do |group|
-            if group[:already_colorized]
-              group[:lines]
-            else
-              group[:lines].map do |line|
-                if line.strip.empty?
-                  line
-                else
-                  indentation = line[/^[ ]+/]
-                  rest = colorizer.wrap(line.sub(/^[ ]+/, ''), message_color)
-
-                  if indentation
-                    indentation + rest
+          # Override to only color uncolored lines in red
+          # and to not color empty lines
+          def colorized_message_lines(colorizer = ::RSpec::Core::Formatters::ConsoleCodes)
+            lines = failure_line_groups.flat_map do |group|
+              if group[:already_colorized]
+                group[:lines]
+              else
+                group[:lines].map do |line|
+                  if line.strip.empty?
+                    line
                   else
-                    rest
+                    indentation = line[/^[ ]+/]
+                    rest = colorizer.wrap(line.sub(/^[ ]+/, ''), message_color)
+
+                    if indentation
+                      indentation + rest
+                    else
+                      rest
+                    end
                   end
                 end
               end
             end
+
+            add_shared_group_lines(lines, colorizer)
           end
 
-          add_shared_group_lines(lines, colorizer)
-        end
+          private
 
-        private
+          def add_shared_group_lines(lines, colorizer)
+            return lines if @skip_shared_group_trace
 
-        def add_shared_group_lines(lines, colorizer)
-          return lines if @skip_shared_group_trace
+            example.metadata[:shared_group_inclusion_backtrace].each do |frame|
+              # Use red instead of the default color
+              lines << colorizer.wrap(frame.description, :failure)
+            end
 
-          example.metadata[:shared_group_inclusion_backtrace].each do |frame|
-            # Use red instead of the default color
-            lines << colorizer.wrap(frame.description, :failure)
+            lines
           end
 
-          lines
-        end
-
-        # Considering that `failure_slash_error_lines` is already colored,
-        # extract this from the other lines so that they, too, can be colored,
-        # later
-        #
-        # TODO: Refactor this somehow
-        #
-        def failure_line_groups
-          if defined?(@failure_line_groups)
-            @failure_line_groups
-          else
-            @failure_line_groups = [
-              {
-                lines: failure_slash_error_lines,
-                already_colorized: true
-              }
-            ]
-
-            sections = [failure_slash_error_lines, exception_lines]
-            separate_groups = (
-              sections.any? { |section| section.size > 1 } &&
-              !exception_lines.first.empty?
-            )
-
-            if separate_groups
-              @failure_line_groups << { lines: [''], already_colorized: true }
-            end
-
-            already_colorized = exception_lines.any? do |line|
-              SuperDiff::Csi.already_colorized?(line)
-            end
-
-            if already_colorized
-              @failure_line_groups << {
-                lines: exception_lines,
-                already_colorized: true
-              }
+          # Considering that `failure_slash_error_lines` is already colored,
+          # extract this from the other lines so that they, too, can be colored,
+          # later
+          #
+          # TODO: Refactor this somehow
+          #
+          def failure_line_groups
+            if defined?(@failure_line_groups)
+              @failure_line_groups
             else
-              locatable_exception_lines =
-                exception_lines.each_with_index.map do |line, index|
-                  { text: line, index: index }
-                end
-
-              boundary_line =
-                locatable_exception_lines.find do |line, index|
-                  line[:text].strip.empty? || line[:text].match?(/^    /)
-                end
-
-              if boundary_line
-                @failure_line_groups << {
-                  lines: exception_lines[0..boundary_line[:index] - 1],
-                  already_colorized: false
+              @failure_line_groups = [
+                {
+                  lines: failure_slash_error_lines,
+                  already_colorized: true
                 }
+              ]
+
+              sections = [failure_slash_error_lines, exception_lines]
+              separate_groups = (
+                sections.any? { |section| section.size > 1 } &&
+                !exception_lines.first.empty?
+              )
+
+              if separate_groups
+                @failure_line_groups << { lines: [''], already_colorized: true }
+              end
+
+              already_colorized = exception_lines.any? do |line|
+                SuperDiff::Csi.already_colorized?(line)
+              end
+
+              if already_colorized
                 @failure_line_groups << {
-                  lines: exception_lines[boundary_line[:index]..-1],
+                  lines: exception_lines,
                   already_colorized: true
                 }
               else
-                @failure_line_groups << {
-                  lines: exception_lines,
-                  already_colorized: false
-                }
+                locatable_exception_lines =
+                  exception_lines.each_with_index.map do |line, index|
+                    { text: line, index: index }
+                  end
+
+                boundary_line =
+                  locatable_exception_lines.find do |line, index|
+                    line[:text].strip.empty? || line[:text].match?(/^    /)
+                  end
+
+                if boundary_line
+                  @failure_line_groups << {
+                    lines: exception_lines[0..boundary_line[:index] - 1],
+                    already_colorized: false
+                  }
+                  @failure_line_groups << {
+                    lines: exception_lines[boundary_line[:index]..-1],
+                    already_colorized: true
+                  }
+                else
+                  @failure_line_groups << {
+                    lines: exception_lines,
+                    already_colorized: false
+                  }
+                end
               end
+
+              @failure_line_groups
             end
-
-            @failure_line_groups
-          end
-        end
-
-        # Style the first part in white and don't style the snippet of the line
-        def failure_slash_error_lines
-          lines = read_failed_lines
-
-          failure_slash_error = ConsoleCodes.wrap("Failure/Error: ", :bold)
-
-          if lines.count == 1
-            lines[0] = failure_slash_error + lines[0].strip
-          else
-            least_indentation = SnippetExtractor.least_indentation_from(lines)
-            lines = lines.map do |line|
-              line.sub(/^#{least_indentation}/, '  ')
-            end
-            lines.unshift(failure_slash_error)
           end
 
-          lines
-        end
+          # Style the first part in white and don't style the snippet of the line
+          def failure_slash_error_lines
+            lines = read_failed_lines
 
-        # Exclude this file from being included in backtraces, so that the
-        # SnippetExtractor prints the right thing
-        def find_failed_line
-          line_regex = RSpec.configuration.in_project_source_dir_regex
-          loaded_spec_files = RSpec.configuration.loaded_spec_files
+            failure_slash_error = ConsoleCodes.wrap("Failure/Error: ", :bold)
 
-          exception_backtrace.find do |line|
-            next unless (line_path = line[/(.+?):(\d+)(|:\d+)/, 1])
-            path = File.expand_path(line_path)
-            path != __FILE__ && (loaded_spec_files.include?(path) || path =~ line_regex)
-          end || exception_backtrace.first
+            if lines.count == 1
+              lines[0] = failure_slash_error + lines[0].strip
+            else
+              least_indentation = SnippetExtractor.least_indentation_from(lines)
+              lines = lines.map do |line|
+                line.sub(/^#{least_indentation}/, '  ')
+              end
+              lines.unshift(failure_slash_error)
+            end
+
+            lines
+          end
+
+          # Exclude this file from being included in backtraces, so that the
+          # SnippetExtractor prints the right thing
+          def find_failed_line
+            line_regex = RSpec.configuration.in_project_source_dir_regex
+            loaded_spec_files = RSpec.configuration.loaded_spec_files
+
+            exception_backtrace.find do |line|
+              next unless (line_path = line[/(.+?):(\d+)(|:\d+)/, 1])
+              path = File.expand_path(line_path)
+              path != __FILE__ && (loaded_spec_files.include?(path) || path =~ line_regex)
+            end || exception_backtrace.first
+          end
         end
       end
 
       class SyntaxHighlighter
-        private
+        SuperDiff.insert_overrides(self) do
+          private
 
-        def implementation
-          RSpec::Core::Formatters::SyntaxHighlighter::NoSyntaxHighlightingImplementation
+          def implementation
+            RSpec::Core::Formatters::SyntaxHighlighter::NoSyntaxHighlightingImplementation
+          end
         end
       end
     end
@@ -253,100 +263,108 @@ module RSpec
 
   module Support
     class ObjectFormatter
-      # Override to use our formatting algorithm
-      def self.format(value)
-        SuperDiff.inspect_object(value, as_single_line: true)
+      SuperDiff.insert_singleton_overrides(self) do
+        # Override to use our formatting algorithm
+        def format(value)
+          SuperDiff.inspect_object(value, as_single_line: true)
+        end
       end
 
-      # Override to use our formatting algorithm
-      def format(value)
-        SuperDiff.inspect_object(value, as_single_line: true)
+      SuperDiff.insert_overrides(self) do
+        # Override to use our formatting algorithm
+        def format(value)
+          SuperDiff.inspect_object(value, as_single_line: true)
+        end
       end
     end
   end
 
   module Matchers
     class ExpectedsForMultipleDiffs
-      # Add a key for different sides
-      def self.from(expected)
-        return expected if self === expected
+      SuperDiff.insert_singleton_overrides(self) do
+        # Add a key for different sides
+        def from(expected)
+          return expected if self === expected
 
-        text =
-          colorizer.wrap("Diff:", SuperDiff.configuration.header_color) +
-          "\n\n" +
-          colorizer.wrap(
-            "┌ (Key) ──────────────────────────┐",
-            SuperDiff.configuration.border_color
-          ) +
-          "\n" +
-          colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-          colorizer.wrap(
-            "‹-› in expected, not in actual",
-            SuperDiff.configuration.expected_color
-          ) +
-          colorizer.wrap("  │", SuperDiff.configuration.border_color) +
-          "\n" +
-          colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-          colorizer.wrap(
-            "‹+› in actual, not in expected",
-            SuperDiff.configuration.actual_color
-          ) +
-          colorizer.wrap("  │", SuperDiff.configuration.border_color) +
-          "\n" +
-          colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-          "‹ › in both expected and actual" +
-          colorizer.wrap(" │", SuperDiff.configuration.border_color) +
-          "\n" +
-          colorizer.wrap(
-            "└─────────────────────────────────┘",
-            SuperDiff.configuration.border_color
-          )
+          text =
+            colorizer.wrap("Diff:", SuperDiff.configuration.header_color) +
+            "\n\n" +
+            colorizer.wrap(
+              "┌ (Key) ──────────────────────────┐",
+              SuperDiff.configuration.border_color
+            ) +
+            "\n" +
+            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+            colorizer.wrap(
+              "‹-› in expected, not in actual",
+              SuperDiff.configuration.expected_color
+            ) +
+            colorizer.wrap("  │", SuperDiff.configuration.border_color) +
+            "\n" +
+            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+            colorizer.wrap(
+              "‹+› in actual, not in expected",
+              SuperDiff.configuration.actual_color
+            ) +
+            colorizer.wrap("  │", SuperDiff.configuration.border_color) +
+            "\n" +
+            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+            "‹ › in both expected and actual" +
+            colorizer.wrap(" │", SuperDiff.configuration.border_color) +
+            "\n" +
+            colorizer.wrap(
+              "└─────────────────────────────────┘",
+              SuperDiff.configuration.border_color
+            )
 
-        new([[expected, text]])
-      end
+          new([[expected, text]])
+        end
 
-      def self.colorizer
-        RSpec::Core::Formatters::ConsoleCodes
-      end
-
-      # Add an extra line break
-      def message_with_diff(message, differ, actual)
-        diff = diffs(differ, actual)
-
-        if diff.empty?
-          message
-        else
-          "#{message.rstrip}\n\n#{diff}"
+        def colorizer
+          RSpec::Core::Formatters::ConsoleCodes
         end
       end
 
-      private
+      SuperDiff.insert_overrides(self) do
+        # Add an extra line break
+        def message_with_diff(message, differ, actual)
+          diff = diffs(differ, actual)
 
-      # Add extra line breaks in between diffs, and colorize the word "Diff"
-      def diffs(differ, actual)
-        @expected_list.map do |(expected, diff_label)|
-          diff = differ.diff(actual, expected)
-          next if diff.strip.empty?
-          diff_label + diff
-        end.compact.join("\n\n")
+          if diff.empty?
+            message
+          else
+            "#{message.rstrip}\n\n#{diff}"
+          end
+        end
+
+        private
+
+        # Add extra line breaks in between diffs, and colorize the word "Diff"
+        def diffs(differ, actual)
+          @expected_list.map do |(expected, diff_label)|
+            diff = differ.diff(actual, expected)
+            next if diff.strip.empty?
+            diff_label + diff
+          end.compact.join("\n\n")
+        end
       end
     end
 
     module BuiltIn
       class Be
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def expected_for_matcher_text
             "truthy"
           end
-        end)
+        end
       end
 
       class BeComparedTo
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def expected_action_for_matcher_text
             if [:==, :===, :=~].include?(@operator)
               "#{@operator}"
@@ -354,13 +372,13 @@ module RSpec
               "be #{@operator}"
             end
           end
-        end)
+        end
       end
 
       class BeFalsey
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def expected_action_for_matcher_text
             "be"
           end
@@ -368,13 +386,13 @@ module RSpec
           def expected_for_matcher_text
             "falsey"
           end
-        end)
+        end
       end
 
       class BeNil
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def expected_action_for_matcher_text
             "be"
           end
@@ -382,13 +400,13 @@ module RSpec
           def expected_for_matcher_text
             "nil"
           end
-        end)
+        end
       end
 
       class BePredicate
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def actual_for_matcher_text
             actual
           end
@@ -416,13 +434,13 @@ module RSpec
               expected_predicate_method_name: predicate
             )
           end
-        end)
+        end
       end
 
       class BeTruthy
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def expected_action_for_matcher_text
             "be"
           end
@@ -430,13 +448,13 @@ module RSpec
           def expected_for_matcher_text
             "truthy"
           end
-        end)
+        end
       end
 
       class ContainExactly
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           # Override this method so that the differ knows that this is a partial
           # collection
           def expected_for_diff
@@ -452,21 +470,26 @@ module RSpec
           def matcher_text_builder_class
             SuperDiff::RSpec::MatcherTextBuilders::ContainExactly
           end
-        end)
+        end
       end
 
       class Eq
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
       end
 
       class Equal
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
       end
 
       class HaveAttributes
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
+          def initialize(*)
+            super
+            @actual = nil
+          end
+
           # Use the message in the base matcher
           def failure_message
             respond_to_failure_message_or { super }
@@ -502,48 +525,48 @@ module RSpec
               matchers.an_object_having_attributes(@expected)
             end
           end
-        end)
 
-        # Override to force @values to get populated so that we can show a
-        # proper diff
-        def respond_to_attributes?
-          cache_all_values
-          matches = respond_to_matcher.matches?(@actual)
-          @respond_to_failed = !matches
-          matches
-        end
+          # Override to force @values to get populated so that we can show a
+          # proper diff
+          def respond_to_attributes?
+            cache_all_values
+            matches = respond_to_matcher.matches?(@actual)
+            @respond_to_failed = !matches
+            matches
+          end
 
-        # Override this method to skip non-existent attributes, and to use
-        # public_send
-        def cache_all_values
-          @values = @expected.keys.inject({}) do |hash, attribute_key|
-            if @actual.respond_to?(attribute_key)
-              actual_value = @actual.public_send(attribute_key)
-              hash.merge(attribute_key => actual_value)
-            else
-              hash
+          # Override this method to skip non-existent attributes, and to use
+          # public_send
+          def cache_all_values
+            @values = @expected.keys.inject({}) do |hash, attribute_key|
+              if @actual.respond_to?(attribute_key)
+                actual_value = @actual.public_send(attribute_key)
+                hash.merge(attribute_key => actual_value)
+              else
+                hash
+              end
             end
           end
-        end
 
-        def actual_has_attribute?(attribute_key, attribute_value)
-          values_match?(attribute_value, @values.fetch(attribute_key))
-        end
+          def actual_has_attribute?(attribute_key, attribute_value)
+            values_match?(attribute_value, @values.fetch(attribute_key))
+          end
 
-        # Override to not improve_hash_formatting
-        def respond_to_failure_message_or
-          if respond_to_failed
-            respond_to_matcher.failure_message
-          else
-            yield
+          # Override to not improve_hash_formatting
+          def respond_to_failure_message_or
+            if respond_to_failed
+              respond_to_matcher.failure_message
+            else
+              yield
+            end
           end
         end
       end
 
       class Has
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def actual_for_matcher_text
             actual
           end
@@ -570,13 +593,18 @@ module RSpec
               private_predicate: private_predicate?
             )
           end
-        end)
+        end
       end
 
       class Include
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
+          def initialize(*)
+            super
+            @actual = nil
+          end
+
           # Override this method so that the differ knows that this is a partial
           # array or hash
           def expected_for_diff
@@ -611,7 +639,11 @@ module RSpec
           def expected_for_failure_message
             # TODO: Switch to using @divergent_items and handle this in the text
             # builder
-            readable_list_of(@divergent_items).lstrip
+            if defined?(@divergent_items)
+              readable_list_of(@divergent_items).lstrip
+            else
+              ""
+            end
           end
 
           # Update to use (...) as delimiter instead of {...}
@@ -624,13 +656,13 @@ module RSpec
               super
             end
           end
-        end)
+        end
       end
 
       class Match
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def matcher_text_builder_class
             SuperDiff::RSpec::MatcherTextBuilders::Match
           end
@@ -638,7 +670,7 @@ module RSpec
           def matcher_text_builder_args
             super.merge(expected_captures: @expected_captures)
           end
-        end)
+        end
       end
 
       class MatchArray < ContainExactly
@@ -652,9 +684,9 @@ module RSpec
       end
 
       class RaiseError
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def actual_for_matcher_text
             if @actual_error
               "#<#{@actual_error.class.name} #{@actual_error.message.inspect}>"
@@ -696,7 +728,7 @@ module RSpec
           def matcher_text_builder_class
             SuperDiff::RSpec::MatcherTextBuilders::RaiseError
           end
-        end)
+        end
 
         def self.matcher_name
           "raise error"
@@ -704,9 +736,9 @@ module RSpec
       end
 
       class RespondTo
-        prepend SuperDiff::RSpec::AugmentedMatcher
+        SuperDiff.insert_overrides(self, SuperDiff::RSpec::AugmentedMatcher)
 
-        prepend(Module.new do
+        SuperDiff.insert_overrides(self) do
           def initialize(*)
             super
             @failing_method_names = nil
@@ -732,13 +764,20 @@ module RSpec
           def expected_for_failure_message
             @failing_method_names
           end
-        end)
+        end
       end
     end
 
-    def match_array(items)
-      BuiltIn::MatchArray.new(items.is_a?(String) ? [items] : items)
+    SuperDiff.insert_overrides(self) do
+      def self.prepended(base)
+        base.class_eval do
+          alias_matcher :an_array_matching, :match_array
+        end
+      end
+
+      def match_array(items)
+        BuiltIn::MatchArray.new(items.is_a?(String) ? [items] : items)
+      end
     end
-    alias_matcher :an_array_matching, :match_array
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,6 +72,14 @@ RSpec.configure do |config|
   end
 end
 
+require "warnings_logger"
+$VERBOSE = true
+WarningsLogger.configure do |config|
+  config.project_name = "super_diff"
+  config.project_directory = Pathname.new("..").expand_path(__dir__)
+end
+WarningsLogger.enable
+
 if active_record_available
   require "super_diff/rspec-rails"
 else

--- a/support/test_plan.rb
+++ b/support/test_plan.rb
@@ -1,4 +1,5 @@
 require "pathname"
+require "optparse"
 
 require_relative "../support/current_bundle"
 
@@ -28,6 +29,14 @@ class TestPlan
       require "pry-byebug"
     rescue LoadError
       require "pry-nav"
+    end
+
+    if SuperDiff::CurrentBundle.instance.current_appraisal.name.start_with?("no_rails_")
+      require "rspec"
+    else
+      require "rails"
+      require "rspec"
+      require "rspec-rails"
     end
 
     require "super_diff"
@@ -128,13 +137,6 @@ class TestPlan
     end
 
     SuperDiff::Csi.color_enabled = color_enabled?
-
-    if SuperDiff::CurrentBundle.instance.current_appraisal.name.start_with?("no_rails_")
-      require "rspec"
-    else
-      require "rails"
-      require "rspec-rails"
-    end
 
     RSpec.configure do |config|
       config.color_mode = color_enabled? ? :on : :off

--- a/zeus.json
+++ b/zeus.json
@@ -1,5 +1,5 @@
 {
-  "command": "ruby -r ./config/zeus_plan.rb -e Zeus.go",
+  "command": "ruby -r rubygems -r ./config/zeus_plan.rb -e Zeus.go",
   "plan": {
     "boot": {
       "run_plain_test": [],


### PR DESCRIPTION
When running tests locally, multiple warnings were being emitted. A lot
of these warnings have to do with the fact that we are overriding core
methods in RSpec, and whenever you override a method, Ruby feels the
need to inform you. To get around this, we need to use the same trick
that we already use for AugmentedMatcher: we create a module on the fly
and `prepend` it to the class or module in question. Sometimes we might
even need to `prepend` to the singleton class. Also, this commit adds
WarningsLogger so that we can track when this happens again.