### PR TITLE
Add support for rspec-mocks argument macthers

### DIFF
--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -57,6 +57,12 @@ module SuperDiff
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeAKindOf)
     end
 
+    # HINT: `a_kind_of` is a matcher in the rspec-expectations gem.
+    #       `kind_of` is an argument matcher in the rspec-mocks gem.
+    def self.kind_of_something?(value)
+      value.is_a?(::RSpec::Mocks::ArgumentMatchers::KindOf)
+    end
+
     def self.an_instance_of_something?(value)
       fuzzy_object?(value) &&
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeAnInstanceOf)

--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -26,6 +26,12 @@ module SuperDiff
         value.expecteds.first.is_a?(::Hash)
     end
 
+    # HINT: `a_hash_including` is an alias of `include` in the rspec-expectations gem.
+    #       `hash_including` is an argument matcher in the rspec-mocks gem.
+    def self.hash_including_something?(value)
+      value.is_a?(::RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher)
+    end
+
     def self.a_collection_including_something?(value)
       fuzzy_object?(value) &&
         value.respond_to?(:expecteds) &&

--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -38,6 +38,10 @@ module SuperDiff
         !(value.expecteds.one? && value.expecteds.first.is_a?(::Hash))
     end
 
+    def self.array_including_something?(value)
+      value.is_a?(::RSpec::Mocks::ArgumentMatchers::ArrayIncludingMatcher)
+    end
+
     def self.an_object_having_some_attributes?(value)
       fuzzy_object?(value) &&
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::HaveAttributes)

--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -68,6 +68,12 @@ module SuperDiff
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeAnInstanceOf)
     end
 
+    # HINT: `an_instance_of` is a matcher in the rspec-expectations gem.
+    #       `instance_of` is an argument matcher in the rspec-mocks gem.
+    def self.instance_of_something?(value)
+      value.is_a?(::RSpec::Mocks::ArgumentMatchers::InstanceOf)
+    end
+
     def self.a_value_within_something?(value)
       fuzzy_object?(value) &&
         value.base_matcher.is_a?(::RSpec::Matchers::BuiltIn::BeWithin)

--- a/lib/super_diff/rspec/differs/collection_including.rb
+++ b/lib/super_diff/rspec/differs/collection_including.rb
@@ -3,8 +3,10 @@ module SuperDiff
     module Differs
       class CollectionIncluding < SuperDiff::Differs::Array
         def self.applies_to?(expected, actual)
-          SuperDiff::RSpec.a_collection_including_something?(expected) &&
-            actual.is_a?(::Array)
+          (
+            SuperDiff::RSpec.a_collection_including_something?(expected) ||
+            SuperDiff::RSpec.array_including_something?(expected)
+          ) && actual.is_a?(::Array)
         end
 
         private

--- a/lib/super_diff/rspec/differs/hash_including.rb
+++ b/lib/super_diff/rspec/differs/hash_including.rb
@@ -3,8 +3,10 @@ module SuperDiff
     module Differs
       class HashIncluding < SuperDiff::Differs::Hash
         def self.applies_to?(expected, actual)
-          SuperDiff::RSpec.a_hash_including_something?(expected) &&
-            actual.is_a?(::Hash)
+          (
+            SuperDiff::RSpec.a_hash_including_something?(expected) ||
+            SuperDiff::RSpec.hash_including_something?(expected)
+          ) && actual.is_a?(::Hash)
         end
 
         private

--- a/lib/super_diff/rspec/object_inspection/inspectors/collection_including.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/collection_including.rb
@@ -4,7 +4,7 @@ module SuperDiff
       module Inspectors
         class CollectionIncluding < SuperDiff::ObjectInspection::Inspectors::Base
           def self.applies_to?(value)
-            SuperDiff::RSpec.a_collection_including_something?(value)
+            SuperDiff::RSpec.a_collection_including_something?(value) || SuperDiff::RSpec.array_including_something?(value)
           end
 
           protected
@@ -13,8 +13,13 @@ module SuperDiff
             SuperDiff::ObjectInspection::InspectionTree.new do
               add_text "#<a collection including ("
 
-              nested do |aliased_matcher|
-                insert_array_inspection_of(aliased_matcher.expecteds)
+              nested do |value|
+                array = if SuperDiff::RSpec.a_collection_including_something?(value)
+                          value.expecteds
+                        else
+                          value.instance_variable_get(:@expected)
+                        end
+                insert_array_inspection_of(array)
               end
 
               add_break

--- a/lib/super_diff/rspec/object_inspection/inspectors/hash_including.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/hash_including.rb
@@ -4,7 +4,7 @@ module SuperDiff
       module Inspectors
         class HashIncluding < SuperDiff::ObjectInspection::Inspectors::Base
           def self.applies_to?(value)
-            SuperDiff::RSpec.a_hash_including_something?(value)
+            SuperDiff::RSpec.a_hash_including_something?(value) || SuperDiff::RSpec.hash_including_something?(value)
           end
 
           protected
@@ -13,9 +13,14 @@ module SuperDiff
             SuperDiff::ObjectInspection::InspectionTree.new do
               add_text "#<a hash including ("
 
-              nested do |aliased_matcher|
+              nested do |value|
+                hash = if SuperDiff::RSpec.a_hash_including_something?(value)
+                         value.expecteds.first
+                       else
+                         value.instance_variable_get(:@expected)
+                       end
                 insert_hash_inspection_of(
-                  aliased_matcher.expecteds.first,
+                  hash,
                   initial_break: nil,
                 )
               end

--- a/lib/super_diff/rspec/object_inspection/inspectors/instance_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/instance_of.rb
@@ -4,15 +4,20 @@ module SuperDiff
       module Inspectors
         class InstanceOf < SuperDiff::ObjectInspection::Inspectors::Base
           def self.applies_to?(value)
-            SuperDiff::RSpec.an_instance_of_something?(value)
+            SuperDiff::RSpec.an_instance_of_something?(value) || SuperDiff::RSpec.instance_of_something?(value)
           end
 
           protected
 
           def inspection_tree
             SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text do |aliased_matcher|
-                "#<an instance of #{aliased_matcher.expected}>"
+              add_text do |value|
+                klass = if SuperDiff::RSpec.an_instance_of_something?(value)
+                          value.expected
+                        else
+                          value.instance_variable_get(:@klass)
+                        end
+                "#<an instance of #{klass}>"
               end
             end
           end

--- a/lib/super_diff/rspec/object_inspection/inspectors/kind_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspectors/kind_of.rb
@@ -4,15 +4,20 @@ module SuperDiff
       module Inspectors
         class KindOf < SuperDiff::ObjectInspection::Inspectors::Base
           def self.applies_to?(value)
-            SuperDiff::RSpec.a_kind_of_something?(value)
+            SuperDiff::RSpec.a_kind_of_something?(value) || SuperDiff::RSpec.kind_of_something?(value)
           end
 
           protected
 
           def inspection_tree
             SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text do |aliased_matcher|
-                "#<a kind of #{aliased_matcher.expected}>"
+              add_text do |value|
+                klass = if SuperDiff::RSpec.a_kind_of_something?(value)
+                          value.expected
+                        else
+                          value.instance_variable_get(:@klass)
+                        end
+                "#<a kind of #{klass}>"
               end
             end
           end

--- a/lib/super_diff/rspec/operation_tree_builders/collection_including.rb
+++ b/lib/super_diff/rspec/operation_tree_builders/collection_including.rb
@@ -3,8 +3,10 @@ module SuperDiff
     module OperationTreeBuilders
       class CollectionIncluding < SuperDiff::OperationTreeBuilders::Array
         def self.applies_to?(expected, actual)
-          SuperDiff::RSpec.a_collection_including_something?(expected) &&
-            actual.is_a?(::Array)
+          (
+            SuperDiff::RSpec.a_collection_including_something?(expected) ||
+            SuperDiff::RSpec.array_including_something?(expected)
+          ) && actual.is_a?(::Array)
         end
 
         def initialize(expected:, actual:, **rest)
@@ -16,7 +18,12 @@ module SuperDiff
         private
 
         def actual_with_extra_items_in_expected_at_end
-          actual + (expected.expecteds - actual)
+          value = if SuperDiff::RSpec.a_collection_including_something?(expected)
+                    expected.expecteds
+                  else
+                    expected.instance_variable_get(:@expected)
+                  end
+          actual + (value - actual)
         end
       end
     end

--- a/lib/super_diff/rspec/operation_tree_builders/hash_including.rb
+++ b/lib/super_diff/rspec/operation_tree_builders/hash_including.rb
@@ -3,12 +3,19 @@ module SuperDiff
     module OperationTreeBuilders
       class HashIncluding < SuperDiff::OperationTreeBuilders::Hash
         def self.applies_to?(expected, actual)
-          SuperDiff::RSpec.a_hash_including_something?(expected) &&
-            actual.is_a?(::Hash)
+          (
+            SuperDiff::RSpec.a_hash_including_something?(expected) ||
+            SuperDiff::RSpec.hash_including_something?(expected)
+          ) && actual.is_a?(::Hash)
         end
 
         def initialize(expected:, **rest)
-          super(expected: expected.expecteds.first, **rest)
+          hash = if SuperDiff::RSpec.a_hash_including_something?(expected)
+                   expected.expecteds.first
+                 else
+                   expected.instance_variable_get(:@expected)
+                 end
+          super(expected: hash, **rest)
         end
 
         private


### PR DESCRIPTION
This PR adds support for diffing [rspec-mocks argument matchers](https://rspec.info/documentation/3.10/rspec-mocks/RSpec/Mocks/ArgumentMatchers.html). I often use `hash_including` in rspec-mocks instead of `a_hash_including` in rspec-expectations for partial hash comparisons. SuperDiff shows a great diff for `a_hash_including`, but `hash_including` doesn't.

In rspec-mocks, there is an argument matcher similar to the matcher provided by rspec-expectations. This PR is primarily aimed at them. The following support has been added:

- `hash_including` (similar to `a_hash_including`)
- `array_including` (similar to `a_collection_including`)
- `kind_of` (similar to `a_kind_of`)
- `instance_of` (similar to `an_instance_of`)

Other than that, rspec-mocks provides useful matchers (e.g. `hash_excluding, `duck_type`, etc.), but they are out of scope here.

### Before

```
Failures:

  1) is expected to match { a: #<RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher:0x00007f92fca5a4d8 @expected={:b=>{:c=>{:d=>2}}}> }
     Failure/Error: expect({ a: { b: { c: { d: 1 }}} }).to match({ a: hash_including(b: { c: { d: 2 } }) })

       Expected { a: { b: { c: { d: 1 } } } }
       to match { a: #<RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher:0x00007f92fca5a4d8 @expected={:b=>{:c=>{:d=>2}}}> }

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘
         {
       -   a: #<RSpec::Mocks::ArgumentMatchers::HashIncludingMatcher:0xaf0 {
       -     @expected={
       -       b: {
       -         c: {
       -           d: 2
       -         }
       -       }
       -     }
       -   }>
       +   a: {
       +     b: {
       +       c: {
       +         d: 1
       +       }
       +     }
       +   }
         }
```

### After

```
Failures:

  1) is expected to match { a: #<a hash including (b: { c: { d: 2 } })> }
     Failure/Error: expect({ a: { b: { c: { d: 1 }}} }).to match({ a: hash_including(b: { c: { d: 2 } }) })

       Expected { a: { b: { c: { d: 1 } } } } to match { a: #<a hash including (b: { c: { d: 2 } })> }.

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         {
           a: {
             b: {
               c: {
       -         d: 2
       +         d: 1
               }
             }
           }
         }
```

Finally, thank you for the great gem. In our project, we had a problem that the diff of the request spec comparing huge JSON was very hard to read, but this gem solved it brilliantly.