### PR TITLE
Display Time-likes with more precision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
@@ -17,6 +17,7 @@ GEM
     attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (4.0.0)
+    climate_control (1.0.0)
     coderay (1.1.3)
     diff-lcs (1.4.4)
     method_source (1.0.0)
@@ -71,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   childprocess
+  climate_control
   pry-byebug
   pry-nav
   rake
@@ -80,4 +82,4 @@ DEPENDENCIES
   warnings_logger
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
@@ -17,6 +17,7 @@ GEM
     attr_extras (6.2.4)
     byebug (11.1.3)
     childprocess (4.0.0)
+    climate_control (1.0.0)
     coderay (1.1.3)
     diff-lcs (1.4.4)
     method_source (1.0.0)
@@ -71,6 +72,7 @@ PLATFORMS
 DEPENDENCIES
   appraisal
   childprocess
+  climate_control
   pry-byebug
   pry-nav
   rake
@@ -80,4 +82,4 @@ DEPENDENCIES
   warnings_logger
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -42,6 +42,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     childprocess (4.0.0)
+    climate_control (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -139,6 +140,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal
   childprocess
+  climate_control
   jdbc-sqlite3
   pry-byebug
   pry-nav

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "appraisal"
 gem "childprocess"
+gem "climate_control"
 gem "pry-byebug", platform: :mri
 gem "pry-nav", platform: :jruby
 gem "rake"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -42,6 +42,7 @@ GEM
     builder (3.2.4)
     byebug (11.1.3)
     childprocess (4.0.0)
+    climate_control (1.0.0)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
@@ -139,6 +140,7 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   appraisal
   childprocess
+  climate_control
   jdbc-sqlite3
   pry-byebug
   pry-nav
@@ -152,4 +154,4 @@ DEPENDENCIES
   warnings_logger
 
 BUNDLED WITH
-   2.1.4
+   2.2.16

--- a/lib/super_diff/operation_tree_builders/defaults.rb
+++ b/lib/super_diff/operation_tree_builders/defaults.rb
@@ -1,5 +1,5 @@
 module SuperDiff
   module OperationTreeBuilders
-    DEFAULTS = [Array, Hash, CustomObject].freeze
+    DEFAULTS = [Array, Hash, TimeLike, CustomObject].freeze
   end
 end

--- a/lib/super_diff/operation_tree_builders/time_like.rb
+++ b/lib/super_diff/operation_tree_builders/time_like.rb
@@ -15,9 +15,9 @@ module SuperDiff
           "hour",
           "min",
           "sec",
-          "nsec",
+          "subsec",
           "zone",
-          "gmt_offset",
+          "utc_offset",
         ]
 
         # If timezones are different, also show a normalized timestamp at the

--- a/spec/integration/rspec/eq_matcher_spec.rb
+++ b/spec/integration/rspec/eq_matcher_spec.rb
@@ -188,10 +188,12 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           expectation: proc {
             line do
               plain    %|Expected |
-              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
-              plain    %| to eq |
-              expected %|2011-12-13 14:15:16.500 UTC +00:00 (Time)|
-              plain    %|.|
+              actual   %|#<Time 2011-12-13 14:15:16 +00:00 (UTC)>|
+            end
+
+            line do
+              plain    %|   to eq |
+              expected %|#<Time 2011-12-13 14:15:16+(1/2) +00:00 (UTC)>|
             end
           },
           diff: proc {
@@ -202,10 +204,10 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
             plain_line    "    hour: 14,"
             plain_line    "    min: 15,"
             plain_line    "    sec: 16,"
-            expected_line "-   nsec: 500000000,"
-            actual_line   "+   nsec: 0,"
+            expected_line "-   subsec: (1/2),"
+            actual_line   "+   subsec: 0,"
             plain_line    "    zone: \"UTC\","
-            plain_line    "    gmt_offset: 0"
+            plain_line    "    utc_offset: 0"
             plain_line    "  }>"
           },
         )
@@ -234,12 +236,12 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           expectation: proc {
             line do
               plain    %| Expected |
-              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              actual   %|#<Time 2011-12-13 14:15:16 +00:00 (UTC)>|
             end
 
             line do
               plain    %|not to eq |
-              expected %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              expected %|#<Time 2011-12-13 14:15:16 +00:00 (UTC)>|
             end
           },
         )
@@ -270,31 +272,41 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
           expectation: proc {
             line do
               plain    %|Expected |
-              actual   %|2011-12-13 14:15:16.000 UTC +00:00 (Time)|
+              actual   %|#<Time 2011-12-13 14:15:16 +00:00 (UTC)>|
             end
 
             line do
               plain    %|   to eq |
-              expected %|2011-12-13 16:15:16.000 CET +01:00 (ActiveSupport::TimeWithZone)|
+              expected %|#<ActiveSupport::TimeWithZone 2011-12-13 16:15:16 +01:00 (CET)>|
             end
           },
           diff: proc {
-            plain_line    "  #<ActiveSupport::TimeWithZone {"
-            plain_line    "    year: 2011,"
-            plain_line    "    month: 12,"
-            plain_line    "    day: 13,"
-            expected_line "-   hour: 16,"
-            actual_line   "+   hour: 14,"
-            plain_line    "    min: 15,"
-            plain_line    "    sec: 16,"
-            plain_line    "    nsec: 0,"
-            expected_line "-   zone: \"CET\","
-            actual_line   "+   zone: \"UTC\","
-            expected_line "-   gmt_offset: 3600,"
-            actual_line   "+   gmt_offset: 0,"
-            expected_line "-   utc: 2011-12-13 15:15:16.000 UTC +00:00 (Time)"
-            actual_line   "+   utc: 2011-12-13 14:15:16.000 UTC +00:00 (Time)"
-            plain_line    "  }>"
+            plain_line    %|  #<ActiveSupport::TimeWithZone {|
+            plain_line    %|    year: 2011,|
+            plain_line    %|    month: 12,|
+            plain_line    %|    day: 13,|
+            expected_line %|-   hour: 16,|
+            actual_line   %|+   hour: 14,|
+            plain_line    %|    min: 15,|
+            plain_line    %|    sec: 16,|
+            plain_line    %|    subsec: 0,|
+            expected_line %|-   zone: \"CET\",|
+            actual_line   %|+   zone: \"UTC\",|
+            expected_line %|-   utc_offset: 3600,|
+            actual_line   %|+   utc_offset: 0,|
+            plain_line    %|    utc: #<Time {|
+            plain_line    %|      year: 2011,|
+            plain_line    %|      month: 12,|
+            plain_line    %|      day: 13,|
+            expected_line %|-     hour: 15,|
+            actual_line   %|+     hour: 14,|
+            plain_line    %|      min: 15,|
+            plain_line    %|      sec: 16,|
+            plain_line    %|      subsec: 0,|
+            plain_line    %|      zone: "UTC",|
+            plain_line    %|      utc_offset: 0|
+            plain_line    %|    }>|
+            plain_line    %|  }>|
           },
         )
 

--- a/spec/integration/rspec/have_attributes_matcher_spec.rb
+++ b/spec/integration/rspec/have_attributes_matcher_spec.rb
@@ -411,7 +411,17 @@ RSpec.describe "Integration with RSpec's #have_attributes matcher", type: :integ
               expected_line %|-   data: #<a hash including (|
               expected_line %|-     active: true|
               expected_line %|-   )>,|
-              expected_line %|-   created_at: #<a value within 1 of 2020-04-09 00:00:00.000 UTC +00:00 (Time)>|
+              expected_line %|-   created_at: #<a value within 1 of #<Time {|
+              expected_line %|-     year: 2020,|
+              expected_line %|-     month: 4,|
+              expected_line %|-     day: 9,|
+              expected_line %|-     hour: 0,|
+              expected_line %|-     min: 0,|
+              expected_line %|-     sec: 0,|
+              expected_line %|-     subsec: 0,|
+              expected_line %|-     zone: "UTC",|
+              expected_line %|-     utc_offset: 0|
+              expected_line %|-   }>>|
               plain_line    %|  }|
             },
           )

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require "pp"
+
 begin
   require "pry-byebug"
 rescue LoadError
@@ -8,7 +10,7 @@ begin
 rescue LoadError
 end
 
-require "pp"
+require "climate_control"
 
 #---
 


### PR DESCRIPTION
Specifically, include subseconds in the inspected version of the
time-like to match the absolute maximum precision you can use when
defining a Time. This means that the following two Times will no longer
appear as though they are the same time when diffed:

    Time.at(1620017167711.0 / 1000)
    Time.local(2021, 5, 2, 22, 46, 7, 710_999)