### PR TITLE
Fixed deprecation notices for 2.7

### DIFF
--- a/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_model.rb
+++ b/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_model.rb
@@ -27,7 +27,13 @@ module SuperDiff
                     add_text "#{name}: "
                   end
 
-                  add_inspection_of object.read_attribute(name)
+                  read_attribute = object.read_attribute(name)
+
+                  if read_attribute.is_a?(Hash)
+                    add_inspection_of(**object.read_attribute(name))
+                  else
+                    add_inspection_of object.read_attribute(name)
+                  end
                 end
               end
 

--- a/lib/super_diff/object_inspection/inspection_tree_builders/default_object.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/default_object.rb
@@ -43,7 +43,13 @@ module SuperDiff
                     add_text "#{name}="
                   end
 
-                  add_inspection_of object.instance_variable_get(name)
+                  object_ivar = object.instance_variable_get(name)
+
+                  if object_ivar.is_a?(Hash)
+                    add_inspection_of(**object_ivar)
+                  else
+                    add_inspection_of object_ivar
+                  end
                 end
               end
 


### PR DESCRIPTION
This will break in Ruby 3.

I've added a type check because just splatting would break if it's a String or `nil` etc. I'm not sure the best way to check for this since my head can't wrap around the idea of how the whole thing is structured. Maybe you can suggest a better implementation @mcmire ?