### PR TITLE
Add VERSION to auto-loaded constants

### DIFF
--- a/lib/super_diff.rb
+++ b/lib/super_diff.rb
@@ -26,6 +26,7 @@ module SuperDiff
   autoload :OperationTreeBuilders, "super_diff/operation_tree_builders"
   autoload :Operations, "super_diff/operations"
   autoload :RecursionGuard, "super_diff/recursion_guard"
+  autoload :VERSION, "super_diff/version"
 
   def self.configure
     yield configuration


### PR DESCRIPTION
# Before

```
irb(main):001:0> $:.unshift 'lib'
irb(main):002:0> require 'super_diff'
=> true
irb(main):003:0> SuperDiff::VERSION
NameError (uninitialized constant SuperDiff::VERSION)
```

# After

```
irb(main):001:0> $:.unshift 'lib'
irb(main):002:0> require 'super_diff'
=> true
irb(main):003:0> SuperDiff::VERSION
=> "0.8.0"
```