### PR TITLE
Bump minitest versions to 5.14.3

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,6 +1,7 @@
 rails_dependencies = proc do
   gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
   gem "jdbc-sqlite3", platform: :jruby
+  gem "net-ftp"
 end
 
 appraisals = {

--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,9 @@
 rails_dependencies = proc do
   gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
   gem "jdbc-sqlite3", platform: :jruby
-  gem "net-ftp"
+  install_if '-> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) }' do
+    gem "net-ftp"
+  end
 end
 
 appraisals = {

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem "appraisal"
+gem "appraisal", github: 'thoughtbot/appraisal', ref: '2f5be65b8e127bd602fd149f395f2f8fa50616a8'
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -9,10 +19,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.1)
     attr_extras (6.2.4)
     byebug (11.1.3)
@@ -62,7 +68,7 @@ GEM
     rubocop-ast (0.3.0)
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
-    thor (1.0.1)
+    thor (1.2.1)
     unicode-display_width (1.7.0)
     warnings_logger (0.1.1)
 
@@ -70,7 +76,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal
+  appraisal!
   childprocess
   climate_control
   pry-byebug

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -9,10 +19,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.1)
     attr_extras (6.2.4)
     byebug (11.1.3)
@@ -62,7 +68,7 @@ GEM
     rubocop-ast (0.3.0)
       parser (>= 2.7.1.4)
     ruby-progressbar (1.10.1)
-    thor (1.0.1)
+    thor (1.2.1)
     unicode-display_width (1.7.0)
     warnings_logger (0.1.1)
 
@@ -70,7 +76,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal
+  appraisal!
   childprocess
   climate_control
   pry-byebug

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (7.1.4)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.0.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_gte_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubis (2.7.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.0.0)

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.0.0"
 gem "railties", "~> 5.0.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (7.1.4)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.0.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_0_rspec_lt_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubis (2.7.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.0.0)

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (8.0.0)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.1.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_gte_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.1.0)

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile
@@ -12,6 +12,7 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.1.0"
 gem "railties", "~> 5.1.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (8.0.0)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.1.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_1_rspec_lt_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.1.0)

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.2.0)

--- a/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_gte_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.2.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 5.2.0"
 gem "railties", "~> 5.2.0"
 gem "sqlite3", "~> 1.3.6", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
@@ -56,7 +56,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
@@ -47,6 +47,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.9.0)
     i18n (1.8.5)
@@ -57,6 +58,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -127,6 +133,9 @@ GEM
     sqlite3 (1.3.13)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 5.2.0)

--- a/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_5_2_rspec_lt_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     arel (9.0.0)
     ast (2.4.1)
     attr_extras (6.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.2.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -46,6 +46,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.5)
@@ -56,6 +57,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.1)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -126,6 +132,9 @@ GEM
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 6.0)

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -55,7 +55,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.1)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.1)
     attr_extras (6.2.4)
     builder (3.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 6.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -17,5 +17,6 @@ gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -12,11 +12,11 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
+gem "net-ftp"
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
-gem "net-ftp"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal"
+gem "appraisal", ref: "2f5be65b8e127bd602fd149f395f2f8fa50616a8", git: "https://github.com/thoughtbot/appraisal"
 gem "childprocess"
 gem "climate_control"
 gem "pry-byebug", platform: :mri
@@ -12,11 +12,14 @@ gem "rubocop"
 gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
-gem "net-ftp"
 gem "activerecord", "~> 6.0"
 gem "railties", "~> 6.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "< 3.10"
 gem "rspec-rails"
+
+install_if -> { Gem::Requirement.new(">= 2.6.0").satisfied_by?(Gem::Version.new(RUBY_VERSION)) } do
+  gem "net-ftp"
+end
 
 gemspec path: "../"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -55,7 +55,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mini_portile2 (2.5.0)
-    minitest (5.14.2)
+    minitest (5.14.3)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/thoughtbot/appraisal
+  revision: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  ref: 2f5be65b8e127bd602fd149f395f2f8fa50616a8
+  specs:
+    appraisal (2.4.1)
+      bundler
+      rake
+      thor (>= 0.14.0)
+
 PATH
   remote: ..
   specs:
@@ -33,10 +43,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    appraisal (2.3.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
     ast (2.4.1)
     attr_extras (6.2.4)
     builder (3.2.4)
@@ -147,7 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 6.0)
   activerecord-jdbcsqlite3-adapter
-  appraisal
+  appraisal!
   childprocess
   climate_control
   jdbc-sqlite3

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile.lock
@@ -46,6 +46,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.2.2)
     diff-lcs (1.4.4)
     erubi (1.10.0)
     i18n (1.8.5)
@@ -56,6 +57,11 @@ GEM
     method_source (1.0.0)
     mini_portile2 (2.5.0)
     minitest (5.14.3)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.3)
+      timeout
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -126,6 +132,9 @@ GEM
     sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
@@ -142,6 +151,7 @@ DEPENDENCIES
   childprocess
   climate_control
   jdbc-sqlite3
+  net-ftp
   pry-byebug
   pry-nav
   railties (~> 6.0)


### PR DESCRIPTION
On https://github.com/mcmire/super_diff/pull/146 I was getting spec failures because the locked version of minitest does not work with rails 3.1.1, so bumping to one that should work: https://github.com/seattlerb/minitest/blob/master/History.rdoc#5143--2021-01-05-

```
minitest-5.[14](https://github.com/mcmire/super_diff/runs/5875858335?check_suite_focus=true#step:5:14).2 requires ruby version < 3.1, >= 2.2, which is incompatible with
the current version, ruby 3.1.1p18
Error: Process completed with exit code 5.
```