### PR TITLE
Use RSpec fuzzy value matching for hash comparison

### DIFF
--- a/lib/super_diff/rspec/operation_tree_builders/hash_including.rb
+++ b/lib/super_diff/rspec/operation_tree_builders/hash_including.rb
@@ -2,6 +2,8 @@ module SuperDiff
   module RSpec
     module OperationTreeBuilders
       class HashIncluding < SuperDiff::OperationTreeBuilders::Hash
+        include ::RSpec::Matchers::Composable
+
         def self.applies_to?(expected, actual)
           (
             SuperDiff::RSpec.a_hash_including_something?(expected) ||
@@ -23,7 +25,7 @@ module SuperDiff
         def should_add_noop_operation?(key)
           !expected.include?(key) || (
             actual.include?(key) &&
-            expected[key] == actual[key]
+            values_match?(expected[key], actual[key])
           )
         end
       end


### PR DESCRIPTION
Hello! 👋 I believe this fixes #150.

The issue seems to be that RSpec uses [fuzzy matching](https://github.com/rspec/rspec-support/blob/528d88ce6fac5f83390bf430d1c47608e9d8d29a/lib/rspec/support/fuzzy_matcher.rb#L8-L24) to [compare hashes in the "include" matcher](https://github.com/rspec/rspec-expectations/blob/1bc30dc41665ade783340d71e1d8f30bf3c9b995/lib/rspec/matchers/built_in/include.rb#L141-L147), while super_diff's current RSpec-specific HashIncluding operation tree builder uses exact equality.

I understand this likely degrades performance, but maybe it's worth it to make the diff line up with RSpec's matching logic.

Eagerly awaiting your feedback!