### PR TITLE
Don't require active_record unless ActiveRecord is defined

### DIFF
--- a/lib/super_diff/rails.rb
+++ b/lib/super_diff/rails.rb
@@ -1,1 +1,1 @@
-require "super_diff/active_record"
+require "super_diff/active_record" if defined?(ActiveRecord)


### PR DESCRIPTION
This caused issues with Rails projects that did not use ActiveRecord

Let me know test-wise what to do, if anything. 