### PR TITLE
Option to disable the key

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,41 @@ end
 See [eight_bit_color.rb](lib/super_diff/csi/eight_bit_color.rb)
 for the list of available colors.
 
+### Enable or disable the key
+
+You can disable the key by changing the following config (default: true)
+
+``` ruby
+SuperDiff.configure do |config|
+  config.key_enabled = false
+end
+```
+
+### Elision
+
+When looking at a large diff for which many of the lines do not change,
+it can be difficult to locate the lines which do. Text-oriented
+diffs such as those you get from a conventional version control system
+solve this problem by removing those unchanged lines from the diff
+entirely. The same can be done in SuperDiff.
+
+``` ruby
+SuperDiff.configure do |config|
+  config.diff_elision_enabled = false
+  config.diff_elision_maximum = 3
+end
+```
+
+* `diff_elision_enabled` — The elision logic is disabled by default so
+  as not to surprise people, so setting this to `true` will turn it on.
+* `diff_elision_maximum` — This number controls what happens to
+   unchanged lines (i.e. lines that are neither "insert" lines nor
+   "delete" lines) that are in between changed lines. If a section of
+   unchanged lines is beyond this number, the gem will elide (a fancy
+   word for remove) the data structures within that section as much as
+   possible until the limit is reached or it cannot go further. Elided
+   lines are replaced with a `# ...` marker.
+
 ### Diffing custom objects
 
 If you are comparing two data structures

--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ end
 See [eight_bit_color.rb](lib/super_diff/csi/eight_bit_color.rb)
 for the list of available colors.
 
-### Enable or disable the key
+### Disabling the key
 
-You can disable the key by changing the following config (default: true)
+You can disable the key by changing the following config (default: true):
 
 ``` ruby
 SuperDiff.configure do |config|
@@ -194,7 +194,7 @@ SuperDiff.configure do |config|
 end
 ```
 
-### Elision
+### Hiding unimportant lines
 
 When looking at a large diff for which many of the lines do not change,
 it can be difficult to locate the lines which do. Text-oriented

--- a/lib/super_diff/configuration.rb
+++ b/lib/super_diff/configuration.rb
@@ -15,6 +15,7 @@ module SuperDiff
       :elision_marker_color,
       :expected_color,
       :header_color,
+      :key_enabled,
     )
 
     def initialize(options = {})
@@ -31,6 +32,7 @@ module SuperDiff
       @extra_operation_tree_builder_classes = [].freeze
       @extra_operation_tree_classes = [].freeze
       @header_color = :white
+      @key_enabled = true
 
       merge!(options)
     end
@@ -52,6 +54,10 @@ module SuperDiff
 
     def diff_elision_enabled?
       @diff_elision_enabled
+    end
+
+    def key_enabled?
+      @key_enabled
     end
 
     def merge!(configuration_or_options)
@@ -131,6 +137,7 @@ module SuperDiff
           extra_operation_tree_builder_classes.dup,
         extra_operation_tree_classes: extra_operation_tree_classes.dup,
         header_color: header_color,
+        key_enabled: key_enabled?,
       }
     end
 

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -286,36 +286,38 @@ module RSpec
         def from(expected)
           return expected if self === expected
 
-          text =
-            colorizer.wrap("Diff:", SuperDiff.configuration.header_color) +
-            "\n\n" +
-            colorizer.wrap(
-              "┌ (Key) ──────────────────────────┐",
-              SuperDiff.configuration.border_color
-            ) +
-            "\n" +
-            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-            colorizer.wrap(
-              "‹-› in expected, not in actual",
-              SuperDiff.configuration.expected_color
-            ) +
-            colorizer.wrap("  │", SuperDiff.configuration.border_color) +
-            "\n" +
-            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-            colorizer.wrap(
-              "‹+› in actual, not in expected",
-              SuperDiff.configuration.actual_color
-            ) +
-            colorizer.wrap("  │", SuperDiff.configuration.border_color) +
-            "\n" +
-            colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
-            "‹ › in both expected and actual" +
-            colorizer.wrap(" │", SuperDiff.configuration.border_color) +
-            "\n" +
-            colorizer.wrap(
-              "└─────────────────────────────────┘",
-              SuperDiff.configuration.border_color
-            )
+          text = colorizer.wrap("Diff:", SuperDiff.configuration.header_color)
+
+          if SuperDiff.configuration.key_enabled?
+            text += "\n\n" +
+              colorizer.wrap(
+                "┌ (Key) ──────────────────────────┐",
+                SuperDiff.configuration.border_color
+              ) +
+              "\n" +
+              colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+              colorizer.wrap(
+                "‹-› in expected, not in actual",
+                SuperDiff.configuration.expected_color
+              ) +
+              colorizer.wrap("  │", SuperDiff.configuration.border_color) +
+              "\n" +
+              colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+              colorizer.wrap(
+                "‹+› in actual, not in expected",
+                SuperDiff.configuration.actual_color
+              ) +
+              colorizer.wrap("  │", SuperDiff.configuration.border_color) +
+              "\n" +
+              colorizer.wrap("│ ", SuperDiff.configuration.border_color) +
+              "‹ › in both expected and actual" +
+              colorizer.wrap(" │", SuperDiff.configuration.border_color) +
+              "\n" +
+              colorizer.wrap(
+                "└─────────────────────────────────┘",
+                SuperDiff.configuration.border_color
+              )
+          end
 
           new([[expected, text]])
         end

--- a/spec/integration/rspec/eq_matcher_spec.rb
+++ b/spec/integration/rspec/eq_matcher_spec.rb
@@ -953,4 +953,8 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
   it_behaves_like "a matcher that supports elided diffs" do
     let(:matcher) { :eq }
   end
+
+  it_behaves_like "a toggleable key" do
+    let(:matcher) { :eq }
+  end
 end

--- a/spec/integration/rspec/eq_matcher_spec.rb
+++ b/spec/integration/rspec/eq_matcher_spec.rb
@@ -954,7 +954,7 @@ RSpec.describe "Integration with RSpec's #eq matcher", type: :integration do
     let(:matcher) { :eq }
   end
 
-  it_behaves_like "a toggleable key" do
+  it_behaves_like "a matcher that supports a toggleable key" do
     let(:matcher) { :eq }
   end
 end

--- a/spec/support/integration/helpers.rb
+++ b/spec/support/integration/helpers.rb
@@ -38,6 +38,7 @@ module SuperDiff
       color_enabled:,
       snippet:,
       expectation:,
+      key_enabled: true, 
       newline_before_expectation: false,
       indentation: 7,
       diff: nil
@@ -64,32 +65,34 @@ module SuperDiff
 
             white_line "Diff:"
 
-            newline
+            if key_enabled
+              newline
 
-            line do
-              blue "┌ (Key) ──────────────────────────┐"
-            end
+              line do
+                blue "┌ (Key) ──────────────────────────┐"
+              end
 
-            line do
-              blue "│ "
-              magenta "‹-› in expected, not in actual"
-              blue "  │"
-            end
+              line do
+                blue "│ "
+                magenta "‹-› in expected, not in actual"
+                blue "  │"
+              end
 
-            line do
-              blue "│ "
-              yellow "‹+› in actual, not in expected"
-              blue "  │"
-            end
+              line do
+                blue "│ "
+                yellow "‹+› in actual, not in expected"
+                blue "  │"
+              end
 
-            line do
-              blue "│ "
-              text "‹ › in both expected and actual"
-              blue " │"
-            end
+              line do
+                blue "│ "
+                text "‹ › in both expected and actual"
+                blue " │"
+              end
 
-            line do
-              blue "└─────────────────────────────────┘"
+              line do
+                blue "└─────────────────────────────────┘"
+              end
             end
 
             newline

--- a/spec/support/shared_examples/key.rb
+++ b/spec/support/shared_examples/key.rb
@@ -1,4 +1,4 @@
-shared_examples_for "a toggleable key" do
+shared_examples_for "a matcher that supports a toggleable key" do
   context "if key_enabled is set to true" do
     it "produces the key" do
       as_both_colored_and_uncolored do |color_enabled|

--- a/spec/support/shared_examples/key.rb
+++ b/spec/support/shared_examples/key.rb
@@ -6,31 +6,11 @@ shared_examples_for "a toggleable key" do
           expected = [
             "Afghanistan",
             "Aland Islands",
-            "Albania",
-            "Algeria",
-            "American Samoa",
-            "Andorra",
-            "Angola",
-            "Antarctica",
-            "Antigua And Barbuda",
-            "Argentina",
-            "Armenia",
-            "Aruba",
-            "Australia"
+            "Albania"
           ]
           actual = [
             "Afghanistan",
             "Aland Islands",
-            "Albania",
-            "Algeria",
-            "American Samoa",
-            "Andorra",
-            "Anguilla",
-            "Antarctica",
-            "Antigua And Barbuda",
-            "Argentina",
-            "Armenia",
-            "Aruba",
             "Australia"
           ]
           expect(actual).to #{matcher}(expected)
@@ -50,34 +30,20 @@ shared_examples_for "a toggleable key" do
           expectation: proc {
             line do
               plain "Expected "
-              # rubocop:disable Layout/LineLength
-              actual %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Anguilla", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
-              # rubocop:enable Layout/LineLength
+              actual %|["Afghanistan", "Aland Islands", "Australia"]|
             end
 
             line do
               plain "   to eq "
-              # rubocop:disable Layout/LineLength
-              expected %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
-              # rubocop:enable Layout/LineLength
+              expected %|["Afghanistan", "Aland Islands", "Albania"]|
             end
           },
           diff: proc {
             plain_line          %|  [|
             plain_line          %|    "Afghanistan",|
             plain_line          %|    "Aland Islands",|
-            plain_line          %|    "Albania",|
-            plain_line          %|    "Algeria",|
-            plain_line          %|    "American Samoa",|
-            plain_line          %|    "Andorra",|
-            expected_line       %|-   "Angola",|
-            actual_line         %|+   "Anguilla",|
-            plain_line          %|    "Antarctica",|
-            plain_line          %|    "Antigua And Barbuda",|
-            plain_line          %|    "Argentina",|
-            plain_line          %|    "Armenia",|
-            plain_line          %|    "Aruba",|
-            plain_line          %|    "Australia"|
+            expected_line       %|-   "Albania"|
+            actual_line         %|+   "Australia"|
             plain_line          %|  ]|
           },
           key_enabled: true,
@@ -97,31 +63,11 @@ shared_examples_for "a toggleable key" do
           expected = [
             "Afghanistan",
             "Aland Islands",
-            "Albania",
-            "Algeria",
-            "American Samoa",
-            "Andorra",
-            "Angola",
-            "Antarctica",
-            "Antigua And Barbuda",
-            "Argentina",
-            "Armenia",
-            "Aruba",
-            "Australia"
+            "Albania"
           ]
           actual = [
             "Afghanistan",
             "Aland Islands",
-            "Albania",
-            "Algeria",
-            "American Samoa",
-            "Andorra",
-            "Anguilla",
-            "Antarctica",
-            "Antigua And Barbuda",
-            "Argentina",
-            "Armenia",
-            "Aruba",
             "Australia"
           ]
           expect(actual).to #{matcher}(expected)
@@ -142,34 +88,20 @@ shared_examples_for "a toggleable key" do
           expectation: proc {
             line do
               plain "Expected "
-              # rubocop:disable Layout/LineLength
-              actual %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Anguilla", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
-              # rubocop:enable Layout/LineLength
+              actual %|["Afghanistan", "Aland Islands", "Australia"]|
             end
 
             line do
               plain "   to eq "
-              # rubocop:disable Layout/LineLength
-              expected %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
-              # rubocop:enable Layout/LineLength
+              expected %|["Afghanistan", "Aland Islands", "Albania"]|
             end
           },
           diff: proc {
             plain_line          %|  [|
             plain_line          %|    "Afghanistan",|
             plain_line          %|    "Aland Islands",|
-            plain_line          %|    "Albania",|
-            plain_line          %|    "Algeria",|
-            plain_line          %|    "American Samoa",|
-            plain_line          %|    "Andorra",|
-            expected_line       %|-   "Angola",|
-            actual_line         %|+   "Anguilla",|
-            plain_line          %|    "Antarctica",|
-            plain_line          %|    "Antigua And Barbuda",|
-            plain_line          %|    "Argentina",|
-            plain_line          %|    "Armenia",|
-            plain_line          %|    "Aruba",|
-            plain_line          %|    "Australia"|
+            expected_line       %|-   "Albania"|
+            actual_line         %|+   "Australia"|
             plain_line          %|  ]|
           },
         )

--- a/spec/support/shared_examples/key.rb
+++ b/spec/support/shared_examples/key.rb
@@ -1,0 +1,183 @@
+shared_examples_for "a toggleable key" do
+  context "if key_enabled is set to true" do
+    it "produces the key" do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          expected = [
+            "Afghanistan",
+            "Aland Islands",
+            "Albania",
+            "Algeria",
+            "American Samoa",
+            "Andorra",
+            "Angola",
+            "Antarctica",
+            "Antigua And Barbuda",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia"
+          ]
+          actual = [
+            "Afghanistan",
+            "Aland Islands",
+            "Albania",
+            "Algeria",
+            "American Samoa",
+            "Andorra",
+            "Anguilla",
+            "Antarctica",
+            "Antigua And Barbuda",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia"
+          ]
+          expect(actual).to #{matcher}(expected)
+        TEST
+        program = make_plain_test_program(
+          snippet,
+          color_enabled: color_enabled,
+          configuration: {
+            key_enabled: true,
+          },
+        )
+
+        expected_output = build_expected_output(
+          color_enabled: color_enabled,
+          snippet: %|expect(actual).to #{matcher}(expected)|,
+          newline_before_expectation: true,
+          expectation: proc {
+            line do
+              plain "Expected "
+              # rubocop:disable Layout/LineLength
+              actual %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Anguilla", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
+              # rubocop:enable Layout/LineLength
+            end
+
+            line do
+              plain "   to eq "
+              # rubocop:disable Layout/LineLength
+              expected %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
+              # rubocop:enable Layout/LineLength
+            end
+          },
+          diff: proc {
+            plain_line          %|  [|
+            plain_line          %|    "Afghanistan",|
+            plain_line          %|    "Aland Islands",|
+            plain_line          %|    "Albania",|
+            plain_line          %|    "Algeria",|
+            plain_line          %|    "American Samoa",|
+            plain_line          %|    "Andorra",|
+            expected_line       %|-   "Angola",|
+            actual_line         %|+   "Anguilla",|
+            plain_line          %|    "Antarctica",|
+            plain_line          %|    "Antigua And Barbuda",|
+            plain_line          %|    "Argentina",|
+            plain_line          %|    "Armenia",|
+            plain_line          %|    "Aruba",|
+            plain_line          %|    "Australia"|
+            plain_line          %|  ]|
+          },
+          key_enabled: true,
+        )
+
+        expect(program).
+          to produce_output_when_run(expected_output).
+          in_color(color_enabled)
+      end
+    end
+  end
+
+  context "if key_enabled is set to false" do
+    it "does not produce the key" do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          expected = [
+            "Afghanistan",
+            "Aland Islands",
+            "Albania",
+            "Algeria",
+            "American Samoa",
+            "Andorra",
+            "Angola",
+            "Antarctica",
+            "Antigua And Barbuda",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia"
+          ]
+          actual = [
+            "Afghanistan",
+            "Aland Islands",
+            "Albania",
+            "Algeria",
+            "American Samoa",
+            "Andorra",
+            "Anguilla",
+            "Antarctica",
+            "Antigua And Barbuda",
+            "Argentina",
+            "Armenia",
+            "Aruba",
+            "Australia"
+          ]
+          expect(actual).to #{matcher}(expected)
+        TEST
+        program = make_plain_test_program(
+          snippet,
+          color_enabled: color_enabled,
+          configuration: {
+            key_enabled: false,
+          },
+        )
+
+        expected_output = build_expected_output(
+          key_enabled: false,
+          color_enabled: color_enabled,
+          snippet: %|expect(actual).to #{matcher}(expected)|,
+          newline_before_expectation: true,
+          expectation: proc {
+            line do
+              plain "Expected "
+              # rubocop:disable Layout/LineLength
+              actual %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Anguilla", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
+              # rubocop:enable Layout/LineLength
+            end
+
+            line do
+              plain "   to eq "
+              # rubocop:disable Layout/LineLength
+              expected %|["Afghanistan", "Aland Islands", "Albania", "Algeria", "American Samoa", "Andorra", "Angola", "Antarctica", "Antigua And Barbuda", "Argentina", "Armenia", "Aruba", "Australia"]|
+              # rubocop:enable Layout/LineLength
+            end
+          },
+          diff: proc {
+            plain_line          %|  [|
+            plain_line          %|    "Afghanistan",|
+            plain_line          %|    "Aland Islands",|
+            plain_line          %|    "Albania",|
+            plain_line          %|    "Algeria",|
+            plain_line          %|    "American Samoa",|
+            plain_line          %|    "Andorra",|
+            expected_line       %|-   "Angola",|
+            actual_line         %|+   "Anguilla",|
+            plain_line          %|    "Antarctica",|
+            plain_line          %|    "Antigua And Barbuda",|
+            plain_line          %|    "Argentina",|
+            plain_line          %|    "Armenia",|
+            plain_line          %|    "Aruba",|
+            plain_line          %|    "Australia"|
+            plain_line          %|  ]|
+          },
+        )
+
+        expect(program).
+          to produce_output_when_run(expected_output).
+          in_color(color_enabled)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #165 

* Add an option to disable the key. This can be useful if trying to save real estate, and you're already familiar with the colors and symbols in the diff.
* Add documentation for the Elision feature.