### PR TITLE
Fix the URL for the build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [version-badge]: http://img.shields.io/gem/v/super_diff.svg
 [rubygems]: http://rubygems.org/gems/super_diff
-[gh-actions-badge]: http://img.shields.io/github/workflow/status/mcmire/super_diff/SuperDiff/master
+[gh-actions-badge]: https://img.shields.io/github/actions/workflow/status/mcmire/super_diff/super_diff.yml?branch=master 
 [downloads-badge]: http://img.shields.io/gem/dtv/super_diff.svg
 [hound]: https://houndci.com
 [issuehunt-badge]: https://img.shields.io/badge/sponsored_through-IssueHunt-2EC28C


### PR DESCRIPTION
Currently the build badge is showing an error.  This fixes the URL and makes the badge show green.