### PR TITLE
Enforce use of Bundler >= 2.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+if !Gem::Requirement.new(">= 2.4").satisfied_by?(
+     Gem::Version.new(Bundler::VERSION)
+   )
+  raise "Bundler >= 2.4 is required. Please update Bundler by running `bundle update --bundler`"
+end
+
 source "https://rubygems.org"
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }

--- a/bin/setup
+++ b/bin/setup
@@ -267,7 +267,7 @@ ensure-project-ruby-dependencies-installed() {
   if [[ $USE_BUNDLER_1 -eq 1 ]] && (! has-bundler || ! [[ $(bundle -v) =~ '^Bundler version 1\.' ]]); then
     gem install bundler:'~> 1.0'
   elif ! has-bundler; then
-    gem install bundler
+    gem install bundler:'>= 2.4.0'
   fi
 
   bundle check || bundle install


### PR DESCRIPTION
We make use of `install_if` in our appraisals. However, if you aren't using Bundler 2.4 then you can't generate any appraisal gemfiles.

This commit enforces the correct version of Bundler by adding a check to the Gemfile itself. This isn't ideal, but we can't simply add `gem "bundler", "~> 2.4"` to the Gemfile because of the new-ish logic in Bundler which [automatically switches to the version of Bundler specified by the `BUNDLED WITH` section in the lockfile][1]. Unfortunately, we can't commit the lockfiles to the repo, so neither adding the `gem` line nor updating the `BUNDLED WITH` would work.

[1]: https://bundler.io/blog/2022/01/23/bundler-v2-3.html