### PR TITLE
Don't load AR integration if it is unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ gemfiles/*.gemfile.lock
 node_modules
 pkg
 spec/examples.txt
+spec/internal
 tmp
 zeus.server.log
 zeus.server-start.log

--- a/Appraisals
+++ b/Appraisals
@@ -3,6 +3,7 @@ rails_dependencies =
     gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
     gem "jdbc-sqlite3", platform: :jruby
     gem "net-ftp"
+    gem "combustion"
   end
 
 appraisals = {
@@ -10,24 +11,21 @@ appraisals = {
     proc do
       instance_eval(&rails_dependencies)
 
-      gem "activerecord", "~> 6.0.0"
-      gem "railties", "~> 6.0.0"
+      gem "rails", "~> 6.0.0"
       gem "sqlite3", "~> 1.4.0", platform: %i[ruby mswin mingw]
     end,
   rails_6_1:
     proc do
       instance_eval(&rails_dependencies)
 
-      gem "activerecord", "~> 6.1.0"
-      gem "railties", "~> 6.1.0"
+      gem "rails", "~> 6.1.0"
       gem "sqlite3", "~> 1.4.0", platform: %i[ruby mswin mingw]
     end,
   rails_7_0:
     proc do
       instance_eval(&rails_dependencies)
 
-      gem "activerecord", "~> 7.0.0"
-      gem "railties", "~> 7.0.0"
+      gem "rails", "~> 7.0.0"
       gem "sqlite3", "~> 1.4.0", platform: %i[ruby mswin mingw]
     end,
   no_rails: proc {},

--- a/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_gte_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 6.0.0"
-gem "railties", "~> 6.0.0"
+gem "combustion"
+gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"

--- a/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_0_rspec_lt_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 6.0.0"
-gem "railties", "~> 6.0.0"
+gem "combustion"
+gem "rails", "~> 6.0.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"

--- a/gemfiles/rails_6_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_1_rspec_gte_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 6.1.0"
-gem "railties", "~> 6.1.0"
+gem "combustion"
+gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"

--- a/gemfiles/rails_6_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_1_rspec_lt_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 6.1.0"
-gem "railties", "~> 6.1.0"
+gem "combustion"
+gem "rails", "~> 6.1.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"

--- a/gemfiles/rails_7_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_7_0_rspec_gte_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 7.0.0"
-gem "railties", "~> 7.0.0"
+gem "combustion"
+gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", ">= 3.10", "< 4"
 gem "rspec-rails"

--- a/gemfiles/rails_7_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_7_0_rspec_lt_3_10.gemfile
@@ -17,8 +17,8 @@ gem "warnings_logger"
 gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
 gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
-gem "activerecord", "~> 7.0.0"
-gem "railties", "~> 7.0.0"
+gem "combustion"
+gem "rails", "~> 7.0.0"
 gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"

--- a/lib/super_diff/rails.rb
+++ b/lib/super_diff/rails.rb
@@ -1,1 +1,2 @@
-require "super_diff/active_record"
+require "super_diff/active_support"
+require "super_diff/active_record" if defined?(ActiveRecord)

--- a/spec/integration/rails/engines_spec.rb
+++ b/spec/integration/rails/engines_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+
+RSpec.describe "Integration with Rails engines", type: :integration do
+  context "when ActiveRecord is not loaded via Combustion" do
+    it "does not fail to load" do
+      as_both_colored_and_uncolored do |color_enabled|
+        program =
+          make_rspec_rails_engine_program(
+            "expect(true).to be(true)",
+            combustion_initialize: [:action_controller],
+            color_enabled: color_enabled
+          )
+
+        expect(program).not_to produce_output_when_run(
+          "uninitialized constant ActiveRecord"
+        ).in_color(color_enabled)
+      end
+    end
+  end
+end

--- a/spec/support/integration/helpers.rb
+++ b/spec/support/integration/helpers.rb
@@ -32,6 +32,18 @@ module SuperDiff
       TestPrograms::RSpecRails.new(test, color_enabled: color_enabled)
     end
 
+    def make_rspec_rails_engine_program(
+      test,
+      color_enabled:,
+      combustion_initialize:
+    )
+      TestPrograms::RspecRailsEngine.new(
+        test,
+        color_enabled: color_enabled,
+        combustion_initialize: combustion_initialize
+      )
+    end
+
     def build_expected_output(
       color_enabled:,
       snippet:,

--- a/spec/support/integration/matchers/produce_output_when_run_matcher.rb
+++ b/spec/support/integration/matchers/produce_output_when_run_matcher.rb
@@ -55,6 +55,12 @@ module SuperDiff
         end
       end
 
+      def failure_message_when_negated
+        "Expected output of test not to produce output, but it did.\n\n" +
+          "Actual output:\n\n" +
+          SuperDiff::Test::OutputHelpers.bookended(actual_output)
+      end
+
       private
 
       attr_reader :expected_output, :program, :output_processor

--- a/spec/support/integration/test_programs/base.rb
+++ b/spec/support/integration/test_programs/base.rb
@@ -112,7 +112,6 @@ module SuperDiff
                 color_enabled: #{color_enabled?.inspect},
                 configuration: #{configuration.inspect}
               )
-              test_plan.boot
               #{test_plan_prelude}
               test_plan.#{test_plan_command}
 

--- a/spec/support/integration/test_programs/plain.rb
+++ b/spec/support/integration/test_programs/plain.rb
@@ -4,6 +4,12 @@ module SuperDiff
       class Plain < Base
         protected
 
+        def test_plan_prelude
+          <<~PRELUDE.strip
+            test_plan.boot
+          PRELUDE
+        end
+
         def test_plan_command
           "run_plain_test"
         end

--- a/spec/support/integration/test_programs/rspec_active_record.rb
+++ b/spec/support/integration/test_programs/rspec_active_record.rb
@@ -5,7 +5,10 @@ module SuperDiff
         protected
 
         def test_plan_prelude
-          "test_plan.boot_active_record"
+          <<~PRELUDE.strip
+            test_plan.boot
+            test_plan.boot_active_record
+          PRELUDE
         end
 
         def test_plan_command

--- a/spec/support/integration/test_programs/rspec_active_support.rb
+++ b/spec/support/integration/test_programs/rspec_active_support.rb
@@ -5,7 +5,10 @@ module SuperDiff
         protected
 
         def test_plan_prelude
-          "test_plan.boot_active_support"
+          <<~PRELUDE.strip
+            test_plan.boot
+            test_plan.boot_active_support
+          PRELUDE
         end
 
         def test_plan_command

--- a/spec/support/integration/test_programs/rspec_rails.rb
+++ b/spec/support/integration/test_programs/rspec_rails.rb
@@ -5,7 +5,10 @@ module SuperDiff
         protected
 
         def test_plan_prelude
-          "test_plan.boot_active_record"
+          <<~PRELUDE.strip
+            test_plan.boot
+            test_plan.boot_active_record
+          PRELUDE
         end
 
         def test_plan_command

--- a/spec/support/integration/test_programs/rspec_rails_engine.rb
+++ b/spec/support/integration/test_programs/rspec_rails_engine.rb
@@ -1,0 +1,30 @@
+module SuperDiff
+  module IntegrationTests
+    module TestPrograms
+      class RspecRailsEngine < Base
+        def initialize(*args, combustion_initialize:, **options)
+          super(*args, **options)
+          @combustion_initialize = combustion_initialize
+        end
+
+        protected
+
+        def test_plan_prelude
+          <<~PRELUDE.strip
+            test_plan.boot_rails_engine(
+              combustion_initialize: #{combustion_initialize.inspect}
+            )
+          PRELUDE
+        end
+
+        def test_plan_command
+          "run_rspec_rails_test"
+        end
+
+        private
+
+        attr_reader :combustion_initialize
+      end
+    end
+  end
+end

--- a/support/test_plan.rb
+++ b/support/test_plan.rb
@@ -110,6 +110,11 @@ class TestPlan
     boot_active_record
   end
 
+  def boot_rails_engine(combustion_initialize: [])
+    require "combustion"
+    Combustion.initialize!(*combustion_initialize)
+  end
+
   def run_plain_test
     run_test_with_libraries("super_diff/rspec")
   end

--- a/zeus.json
+++ b/zeus.json
@@ -12,6 +12,7 @@
       "boot_rails": {
         "run_rspec_rails_test": []
       }
-    }
+    },
+    "boot_rails_engine": []
   }
 }


### PR DESCRIPTION
When writing tests for a project that uses certain parts of Rails, it should still be possible to say `require "super_diff/rails"`, and SuperDiff should only load the integrations that correspond to the available parts. Right now the only two integrations are ActiveSupport and ActiveRecord. ActiveSupport should always be available, but ActiveRecord may not be available, so this commit adds a guard around that integration in particular. It also adds tests for Combustion so we can test that this guard specifically works for engines where ActiveRecord is not being loaded.