### PR TITLE
Only lint changed files when pushing branch

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+. "$(dirname -- "$0")/_/husky.sh"
+
+echo "Fixing changed files with lint violations..."
+
+yarn prettier --write --ignore-unknown $(git diff "$(git merge-base main HEAD)" --name-only) || exit $?
+
+echo
+echo "Auditing dependencies..."
+
+yarn audit || exit $?
+
+echo

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 .yarn/releases
 gemfiles
 vendor/bundle
+yarn.lock

--- a/bin/setup
+++ b/bin/setup
@@ -5,8 +5,8 @@ set -euo pipefail
 ### PROJECT SETUP ##############################################################
 
 provision-project() {
-  banner "Adding simple-git-hooks"
-  yarn simple-git-hooks
+  banner "Setting up Git hooks"
+  yarn setup-git-hooks
 
   banner "Installing appraisals"
   bundle exec appraisal install

--- a/package.json
+++ b/package.json
@@ -4,23 +4,19 @@
   "description": "A more helpful way to view differences between complex data structures in RSpec",
   "private": true,
   "scripts": {
-    "lint": "prettier --check .",
     "audit": "yarn npm audit && bundle exec bundle audit --gemfile-lock ${BUNDLE_GEMFILE:-Gemfile}",
-    "lint:fix": "yarn lint --write"
-  },
-  "simple-git-hooks": {
-    "pre-push": "yarn lint && yarn audit"
+    "lint": "prettier --check .",
+    "lint:fix": "yarn lint --write",
+    "setup-git-hooks": "husky install"
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.3.0",
     "@prettier/plugin-ruby": "^3.2.2",
-    "prettier": "^2.8.7",
-    "simple-git-hooks": "^2.8.1"
+    "husky": "^8.0.3",
+    "prettier": "^2.8.7"
   },
   "packageManager": "yarn@3.4.1",
   "lavamoat": {
-    "allowScripts": {
-      "simple-git-hooks": false
-    }
+    "allowScripts": {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,6 +521,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"husky@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "husky@npm:8.0.3"
+  bin:
+    husky: lib/bin.js
+  checksum: 837bc7e4413e58c1f2946d38fb050f5d7324c6f16b0fd66411ffce5703b294bd21429e8ba58711cd331951ee86ed529c5be4f76805959ff668a337dbfa82a1b0
+  languageName: node
+  linkType: hard
+
 "imurmurhash@npm:^0.1.4":
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
@@ -1025,15 +1034,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git-hooks@npm:^2.8.1":
-  version: 2.8.1
-  resolution: "simple-git-hooks@npm:2.8.1"
-  bin:
-    simple-git-hooks: cli.js
-  checksum: 920d8b3122a102d4790b511a2f033202511f6a08d5105b4e05f05907d407d99f25490da1037643280d622c1951e0d10abacfbeaee64d5f69f1d0e29cf914141f
-  languageName: node
-  linkType: hard
-
 "sshpk@npm:^1.7.0":
   version: 1.17.0
   resolution: "sshpk@npm:1.17.0"
@@ -1110,8 +1110,8 @@ __metadata:
   dependencies:
     "@lavamoat/allow-scripts": ^2.3.0
     "@prettier/plugin-ruby": ^3.2.2
+    husky: ^8.0.3
     prettier: ^2.8.7
-    simple-git-hooks: ^2.8.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
The Git hook that's currently configured will lint all files in the project when a branch is pushed. Linting takes a long time, so to speed this up, only lint the files that have changed in the branch. Also, to make the feedback loop even faster, fix those files instead of just linting.

Also rename the package script to create the Git hooks from `simple-git-hooks` to `setup-git-hooks` (so if we decide not to use `simple-git-hooks` in the future we don't have to rename it again) and update `bin/setup` script to run this script.

Finally, replace `simple-git-hooks` with `husky`. Our hook is now a little bit more complicated as we need to figure out which branch the current branch is based off of, find the files changed in the branch, and run Prettier accordingly. Being able to just commit the hooks to the repo as Husky allows us to do makes it possible to guarantee that we are doing this.