### PR TITLE
Really require Ruby 3.x

### DIFF
--- a/super_diff.gemspec
+++ b/super_diff.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
     SuperDiff is a gem that hooks into RSpec to intelligently display the
     differences between two data structures of any type.
   DESC
-  s.required_ruby_version = [">= 2.4", "< 4"]
+  s.required_ruby_version = ">= 3"
 
   s.files = %w[README.md super_diff.gemspec] + Dir["lib/**/*"]
   s.test_files = Dir["spec/**/*"]


### PR DESCRIPTION
Update the `required_ruby_version` in the gemspec to disallow Rubies less than 3.x.