### PR TITLE
Add inspection tree builder for ActiveSupport::OrderedOptions

### DIFF
--- a/lib/super_diff/active_support.rb
+++ b/lib/super_diff/active_support.rb
@@ -18,7 +18,8 @@ module SuperDiff
         OperationTreeBuilders::HashWithIndifferentAccess
       )
       config.add_extra_inspection_tree_builder_classes(
-        ObjectInspection::InspectionTreeBuilders::HashWithIndifferentAccess
+        ObjectInspection::InspectionTreeBuilders::HashWithIndifferentAccess,
+        ObjectInspection::InspectionTreeBuilders::OrderedOptions
       )
     end
   end

--- a/lib/super_diff/active_support/object_inspection/inspection_tree_builders.rb
+++ b/lib/super_diff/active_support/object_inspection/inspection_tree_builders.rb
@@ -6,6 +6,10 @@ module SuperDiff
           :HashWithIndifferentAccess,
           "super_diff/active_support/object_inspection/inspection_tree_builders/hash_with_indifferent_access"
         )
+        autoload(
+          :OrderedOptions,
+          "super_diff/active_support/object_inspection/inspection_tree_builders/ordered_options"
+        )
       end
     end
   end

--- a/lib/super_diff/active_support/object_inspection/inspection_tree_builders/ordered_options.rb
+++ b/lib/super_diff/active_support/object_inspection/inspection_tree_builders/ordered_options.rb
@@ -1,0 +1,33 @@
+module SuperDiff
+  module ActiveSupport
+    module ObjectInspection
+      module InspectionTreeBuilders
+        class OrderedOptions < SuperDiff::ObjectInspection::InspectionTreeBuilders::Hash
+          def self.applies_to?(value)
+            value.is_a?(::ActiveSupport::OrderedOptions)
+          end
+
+          def call
+            SuperDiff::ObjectInspection::InspectionTree.new do
+              as_lines_when_rendering_to_lines(collection_bookend: :open) do
+                add_text "#<OrderedOptions {"
+              end
+
+              when_rendering_to_string { add_text " " }
+
+              nested do |ordered_options|
+                insert_hash_inspection_of(ordered_options.to_hash)
+              end
+
+              when_rendering_to_string { add_text " " }
+
+              as_lines_when_rendering_to_lines(collection_bookend: :close) do
+                add_text "}>"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,9 @@ RSpec.configure do |config|
   config.default_formatter = "documentation" if !%w[true 1].include?(ENV["CI"])
 
   config.filter_run_excluding active_record: true unless active_record_available
+  unless defined?(ActiveSupport)
+    config.filter_run_excluding active_support: true
+  end
 
   config.order = :random
   Kernel.srand config.seed

--- a/spec/unit/active_support/object_inspection_spec.rb
+++ b/spec/unit/active_support/object_inspection_spec.rb
@@ -1,0 +1,62 @@
+require "spec_helper"
+
+RSpec.describe SuperDiff, type: :unit do
+  describe ".inspect_object",
+           "for ActiveSupport objects",
+           active_support: true do
+    context "given an ActiveSupport::OrderedOptions object" do
+      context "given as_lines: false" do
+        it "returns an inspected version of the object" do
+          string =
+            described_class.inspect_object(
+              ::ActiveSupport::OrderedOptions[name: "Bob", age: 42],
+              as_lines: false
+            )
+          expect(string).to eq(%(#<OrderedOptions { name: "Bob", age: 42 }>))
+        end
+      end
+
+      context "given as_lines: true" do
+        it "returns an inspected version of the object as multiple Lines" do
+          tiered_lines =
+            described_class.inspect_object(
+              ::ActiveSupport::OrderedOptions[name: "Bob", age: 42],
+              as_lines: true,
+              type: :delete,
+              indentation_level: 1
+            )
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 1,
+                value: "#<OrderedOptions {",
+                collection_bookend: :open
+              ),
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 2,
+                prefix: "name: ",
+                value: "\"Bob\"",
+                add_comma: true
+              ),
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 2,
+                prefix: "age: ",
+                value: "42",
+                add_comma: false
+              ),
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 1,
+                value: "}>",
+                collection_bookend: :close
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I believe this fixes #199 and, I suspect, fixes #163. See https://github.com/mcmire/super_diff/issues/199#issuecomment-1793187076 for more background. You can reproduce errors like those raised in the aforementioned issues by checking out 26e1f6c35e3b502981772a6e1e5ce3c372605202 and running `bundle exec rspec spec/unit/active_support/object_inspection_spec.rb`.

The solution I opted for here was to create a hash-like inspector for `ActiveSupport::OrderedOptions` that takes precedence over the default `CustomObject` inspector, which in turn [takes precedence over](https://github.com/mcmire/super_diff/blob/fb6718a2b60bc8135424295cc069a4b984983f77/lib/super_diff/object_inspection/inspection_tree_builders/defaults.rb#L5-L7) the `Hash` inspector.

The `OrderedOptions` inspection tree is basically a copy-paste of the one for `HashWithIndifferentAccess` – let me know if I should try to DRY those up.