### PR TITLE
Condense built-in and DSL RSpec matcher inspection output

### DIFF
--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -112,7 +112,8 @@ module SuperDiff
         ObjectInspection::InspectionTreeBuilders::KindOf,
         ObjectInspection::InspectionTreeBuilders::ObjectHavingAttributes,
         # ObjectInspection::InspectionTreeBuilders::Primitive,
-        ObjectInspection::InspectionTreeBuilders::ValueWithin
+        ObjectInspection::InspectionTreeBuilders::ValueWithin,
+        ObjectInspection::InspectionTreeBuilders::RSpecMatcher
       )
     end
   end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders.rb
@@ -35,6 +35,10 @@ module SuperDiff
           "super_diff/rspec/object_inspection/inspection_tree_builders/primitive"
         )
         autoload(
+          :RSpecMatcher,
+          "super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher"
+        )
+        autoload(
           :ValueWithin,
           "super_diff/rspec/object_inspection/inspection_tree_builders/value_within"
         )

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
@@ -1,0 +1,20 @@
+module SuperDiff
+  module RSpec
+    module ObjectInspection
+      module InspectionTreeBuilders
+        class RSpecMatcher < SuperDiff::ObjectInspection::InspectionTreeBuilders::Base
+          def self.applies_to?(value)
+            value.is_a?(::RSpec::Matchers::BuiltIn::BaseMatcher) ||
+              value.is_a?(::RSpec::Matchers::DSL::Matcher)
+          end
+
+          def call
+            SuperDiff::ObjectInspection::InspectionTree.new do
+              add_text { |object| "(#{object.description})" }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
@@ -10,7 +10,7 @@ module SuperDiff
 
           def call
             SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text { |object| "(#{object.description})" }
+              add_text { |object| "#<#{object.description}>" }
             end
           end
         end

--- a/spec/integration/rspec/unhandled_matcher_spec.rb
+++ b/spec/integration/rspec/unhandled_matcher_spec.rb
@@ -1,0 +1,194 @@
+require "spec_helper"
+
+RSpec.describe "Integration with DSL and other RSpec matchers",
+               type: :integration do
+  let(:matcher_definition) { <<~MATCHER.strip }
+      RSpec::Matchers.define :perfect_square do
+        match do |actual|
+          actual.is_a?(Integer) && actual >= 0 &&
+            (Math.sqrt(actual) % 1).zero?
+        end
+        description { "be a perfect square" }
+      end
+    MATCHER
+  context "when the expected value is a DSL matcher" do
+    it "produces the correct failure message when used in the positive" do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          #{matcher_definition}
+
+          expected = perfect_square
+          actual = 3
+          expect(actual).to match(expected)
+        TEST
+        program = make_plain_test_program(snippet, color_enabled: color_enabled)
+
+        expected_output =
+          build_expected_output(
+            color_enabled: color_enabled,
+            snippet: "expect(actual).to match(expected)",
+            expectation:
+              proc do
+                line do
+                  plain "Expected "
+                  actual "3"
+                  plain " to match "
+                  expected "(be a perfect square)"
+                  plain "."
+                end
+              end
+            # diff:
+            #   proc do
+            #     plain_line "  {"
+            #     expected_line %|-   city: "Hill Valley"|
+            #     actual_line %|+   city: "Burbank"|
+            #     plain_line "  }"
+            #   end
+          )
+
+        expect(program).to produce_output_when_run(expected_output).in_color(
+          color_enabled
+        )
+      end
+    end
+  end
+
+  context "when the expected value contains a DSL matcher" do
+    context "that fails" do
+      it "produces the correct failure message when used in the negative" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            #{matcher_definition}
+
+            expected = hash_including(number: perfect_square)
+            actual = {number: 3}
+            expect(actual).to match(expected)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(actual).to match(expected)",
+              expectation:
+                proc do
+                  line do
+                    plain "Expected "
+                    actual "{ number: 3 }"
+                    plain " to match "
+                    expected "#<a hash including (number: (be a perfect square))>"
+                    plain "."
+                  end
+                end,
+              diff:
+                proc do
+                  plain_line "  {"
+                  expected_line "-   number: (be a perfect square)"
+                  actual_line "+   number: 3"
+                  plain_line "  }"
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+
+    context "that passes while the compound matcher fails" do
+      it "produces the correct failure message when used in the positive" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            #{matcher_definition}
+            expected = a_hash_including(
+              number: perfect_square,
+              string: "hello"
+            )
+            actual = {
+              number: 4,
+              string: "goodbye"
+            }
+            expect(actual).to match(expected)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(actual).to match(expected)",
+              expectation:
+                proc do
+                  line do
+                    plain "Expected "
+                    actual %|{ number: 4, string: "goodbye" }|
+                  end
+
+                  line do
+                    plain "to match "
+                    expected %|#<a hash including (number: (be a perfect square), string: "hello")>|
+                  end
+                end,
+              diff:
+                proc do
+                  plain_line "  {"
+                  plain_line "    number: 4,"
+                  expected_line %|-   string: "hello"|
+                  actual_line %|+   string: "goodbye"|
+                  plain_line "  }"
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+
+      it "produces the correct failure message when used in the negative" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            expected = a_hash_including(
+              city: "Burbank",
+              zip: "90210"
+            )
+            actual = {
+              line_1: "123 Main St.",
+              city: "Burbank",
+              state: "CA",
+              zip: "90210"
+            }
+            expect(actual).not_to match(expected)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(actual).not_to match(expected)",
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "    Expected "
+                    actual %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
+                  end
+
+                  line do
+                    plain "not to match "
+                    expected %|#<a hash including (city: "Burbank", zip: "90210")>|
+                  end
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/rspec/unhandled_matcher_spec.rb
+++ b/spec/integration/rspec/unhandled_matcher_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Integration with built-in RSpec matchers", type: :integration do
                     plain "Expected "
                     actual "{ number: 4 }"
                     plain " not to match "
-                    expected "#<a hash including (number: (be a kind of Numeric))>"
+                    expected "#<a hash including (number: #<be a kind of Numeric>)>"
                     plain "."
                   end
                 end
@@ -63,14 +63,14 @@ RSpec.describe "Integration with built-in RSpec matchers", type: :integration do
                     plain "Expected "
                     actual %|{ number: "not a number" }|
                     plain " to match "
-                    expected "#<a hash including (number: (be a kind of Numeric))>"
+                    expected "#<a hash including (number: #<be a kind of Numeric>)>"
                     plain "."
                   end
                 end,
               diff:
                 proc do
                   plain_line "  {"
-                  expected_line "-   number: (be a kind of Numeric)"
+                  expected_line "-   number: #<be a kind of Numeric>"
                   actual_line %|+   number: "not a number"|
                   plain_line "  }"
                 end

--- a/spec/integration/rspec/unhandled_matcher_spec.rb
+++ b/spec/integration/rspec/unhandled_matcher_spec.rb
@@ -1,164 +1,16 @@
 require "spec_helper"
 
-RSpec.describe "Integration with DSL and other RSpec matchers",
-               type: :integration do
-  let(:matcher_definition) { <<~MATCHER.strip }
-      RSpec::Matchers.define :perfect_square do
-        match do |actual|
-          actual.is_a?(Integer) && actual >= 0 &&
-            (Math.sqrt(actual) % 1).zero?
-        end
-        description { "be a perfect square" }
-      end
-    MATCHER
-  context "when the expected value is a DSL matcher" do
-    it "produces the correct failure message when used in the positive" do
-      as_both_colored_and_uncolored do |color_enabled|
-        snippet = <<~TEST.strip
-          #{matcher_definition}
-
-          expected = perfect_square
-          actual = 3
-          expect(actual).to match(expected)
-        TEST
-        program = make_plain_test_program(snippet, color_enabled: color_enabled)
-
-        expected_output =
-          build_expected_output(
-            color_enabled: color_enabled,
-            snippet: "expect(actual).to match(expected)",
-            expectation:
-              proc do
-                line do
-                  plain "Expected "
-                  actual "3"
-                  plain " to match "
-                  expected "(be a perfect square)"
-                  plain "."
-                end
-              end
-            # diff:
-            #   proc do
-            #     plain_line "  {"
-            #     expected_line %|-   city: "Hill Valley"|
-            #     actual_line %|+   city: "Burbank"|
-            #     plain_line "  }"
-            #   end
-          )
-
-        expect(program).to produce_output_when_run(expected_output).in_color(
-          color_enabled
-        )
-      end
-    end
-  end
-
-  context "when the expected value contains a DSL matcher" do
+RSpec.describe "Integration with built-in RSpec matchers", type: :integration do
+  context "when the expected value contains a built-in matcher" do
     context "that fails" do
       it "produces the correct failure message when used in the negative" do
         as_both_colored_and_uncolored do |color_enabled|
           snippet = <<~TEST.strip
-            #{matcher_definition}
-
-            expected = hash_including(number: perfect_square)
-            actual = {number: 3}
-            expect(actual).to match(expected)
-          TEST
-          program =
-            make_plain_test_program(snippet, color_enabled: color_enabled)
-
-          expected_output =
-            build_expected_output(
-              color_enabled: color_enabled,
-              snippet: "expect(actual).to match(expected)",
-              expectation:
-                proc do
-                  line do
-                    plain "Expected "
-                    actual "{ number: 3 }"
-                    plain " to match "
-                    expected "#<a hash including (number: (be a perfect square))>"
-                    plain "."
-                  end
-                end,
-              diff:
-                proc do
-                  plain_line "  {"
-                  expected_line "-   number: (be a perfect square)"
-                  actual_line "+   number: 3"
-                  plain_line "  }"
-                end
-            )
-
-          expect(program).to produce_output_when_run(expected_output).in_color(
-            color_enabled
-          )
-        end
-      end
-    end
-
-    context "that passes while the compound matcher fails" do
-      it "produces the correct failure message when used in the positive" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            #{matcher_definition}
-            expected = a_hash_including(
-              number: perfect_square,
-              string: "hello"
+            expected = hash_including(
+              number: be_a(Numeric)
             )
             actual = {
-              number: 4,
-              string: "goodbye"
-            }
-            expect(actual).to match(expected)
-          TEST
-          program =
-            make_plain_test_program(snippet, color_enabled: color_enabled)
-
-          expected_output =
-            build_expected_output(
-              color_enabled: color_enabled,
-              snippet: "expect(actual).to match(expected)",
-              expectation:
-                proc do
-                  line do
-                    plain "Expected "
-                    actual %|{ number: 4, string: "goodbye" }|
-                  end
-
-                  line do
-                    plain "to match "
-                    expected %|#<a hash including (number: (be a perfect square), string: "hello")>|
-                  end
-                end,
-              diff:
-                proc do
-                  plain_line "  {"
-                  plain_line "    number: 4,"
-                  expected_line %|-   string: "hello"|
-                  actual_line %|+   string: "goodbye"|
-                  plain_line "  }"
-                end
-            )
-
-          expect(program).to produce_output_when_run(expected_output).in_color(
-            color_enabled
-          )
-        end
-      end
-
-      it "produces the correct failure message when used in the negative" do
-        as_both_colored_and_uncolored do |color_enabled|
-          snippet = <<~TEST.strip
-            expected = a_hash_including(
-              city: "Burbank",
-              zip: "90210"
-            )
-            actual = {
-              line_1: "123 Main St.",
-              city: "Burbank",
-              state: "CA",
-              zip: "90210"
+              number: 4
             }
             expect(actual).not_to match(expected)
           TEST
@@ -169,18 +21,58 @@ RSpec.describe "Integration with DSL and other RSpec matchers",
             build_expected_output(
               color_enabled: color_enabled,
               snippet: "expect(actual).not_to match(expected)",
-              newline_before_expectation: true,
               expectation:
                 proc do
                   line do
-                    plain "    Expected "
-                    actual %|{ line_1: "123 Main St.", city: "Burbank", state: "CA", zip: "90210" }|
+                    plain "Expected "
+                    actual "{ number: 4 }"
+                    plain " not to match "
+                    expected "#<a hash including (number: (be a kind of Numeric))>"
+                    plain "."
                   end
+                end
+            )
 
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+
+      it "produces the correct failure message when used in the positive" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            expected = hash_including(
+              number: be_a(Numeric)
+            )
+            actual = {
+              number: "not a number"
+            }
+            expect(actual).to match(expected)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(actual).to match(expected)",
+              expectation:
+                proc do
                   line do
-                    plain "not to match "
-                    expected %|#<a hash including (city: "Burbank", zip: "90210")>|
+                    plain "Expected "
+                    actual %|{ number: "not a number" }|
+                    plain " to match "
+                    expected "#<a hash including (number: (be a kind of Numeric))>"
+                    plain "."
                   end
+                end,
+              diff:
+                proc do
+                  plain_line "  {"
+                  expected_line "-   number: (be a kind of Numeric)"
+                  actual_line %|+   number: "not a number"|
+                  plain_line "  }"
                 end
             )
 

--- a/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
+++ b/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+
+RSpec.describe SuperDiff, type: :unit do
+  describe ".inspect_object", "for RSpec matchers" do
+    context "given a custom matcher" do
+      let(:custom_matcher) do
+        proc do |expected, &block_arg|
+          declarations =
+            proc do
+              match do |actual|
+                actual.is_a?(Integer) && actual >= 0 &&
+                  (Math.sqrt(actual) % 1).zero?
+              end
+              description { "be a perfect square" }
+            end
+          RSpec::Matchers::DSL::Matcher.new(
+            :be_a_square,
+            declarations,
+            RSpec::Matchers::DSL,
+            *expected,
+            &block_arg
+          )
+        end
+      end
+
+      context "given as_lines: false" do
+        it "returns the matcher's description string" do
+          string =
+            described_class.inspect_object(
+              custom_matcher.call(4),
+              as_lines: false
+            )
+          expect(string).to eq("(be a perfect square)")
+        end
+      end
+
+      context "give as_lines: true" do
+        it "returns an inspected version of the matcher as multiple lines" do
+          tiered_lines =
+            described_class.inspect_object(
+              custom_matcher.call(4),
+              as_lines: true,
+              type: :delete,
+              indentation_level: 1
+            )
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 1,
+                value: "(be a perfect square)"
+              )
+            ]
+          )
+        end
+      end
+    end
+
+    context "given a built-in matcher" do
+      let(:matcher) { be_a(Numeric) }
+
+      context "given as_lines: false" do
+        it "returns the matcher's description string" do
+          string = described_class.inspect_object(matcher, as_lines: false)
+          expect(string).to eq("(be a kind of Numeric)")
+        end
+      end
+
+      context "give as_lines: true" do
+        it "returns an inspected version of the matcher as multiple lines" do
+          tiered_lines =
+            described_class.inspect_object(
+              matcher,
+              as_lines: true,
+              type: :delete,
+              indentation_level: 1
+            )
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 1,
+                value: "(be a kind of Numeric)"
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
+++ b/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SuperDiff, type: :unit do
         end
       end
 
-      context "give as_lines: true" do
+      context "given as_lines: true" do
         it "returns an inspected version of the matcher as multiple lines" do
           tiered_lines =
             described_class.inspect_object(
@@ -66,7 +66,7 @@ RSpec.describe SuperDiff, type: :unit do
         end
       end
 
-      context "give as_lines: true" do
+      context "given as_lines: true" do
         it "returns an inspected version of the matcher as multiple lines" do
           tiered_lines =
             described_class.inspect_object(

--- a/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
+++ b/spec/unit/rspec/object_inspection/rspec_matcher_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SuperDiff, type: :unit do
               custom_matcher.call(4),
               as_lines: false
             )
-          expect(string).to eq("(be a perfect square)")
+          expect(string).to eq("#<be a perfect square>")
         end
       end
 
@@ -48,7 +48,7 @@ RSpec.describe SuperDiff, type: :unit do
               an_object_having_attributes(
                 type: :delete,
                 indentation_level: 1,
-                value: "(be a perfect square)"
+                value: "#<be a perfect square>"
               )
             ]
           )
@@ -62,7 +62,7 @@ RSpec.describe SuperDiff, type: :unit do
       context "given as_lines: false" do
         it "returns the matcher's description string" do
           string = described_class.inspect_object(matcher, as_lines: false)
-          expect(string).to eq("(be a kind of Numeric)")
+          expect(string).to eq("#<be a kind of Numeric>")
         end
       end
 
@@ -80,7 +80,7 @@ RSpec.describe SuperDiff, type: :unit do
               an_object_having_attributes(
                 type: :delete,
                 indentation_level: 1,
-                value: "(be a kind of Numeric)"
+                value: "#<be a kind of Numeric>"
               )
             ]
           )


### PR DESCRIPTION
# Problem

In diff output, some RSpec matchers, such as custom DSL-defined matchers and built-ins like `be_a`, are treated as default objects. This means that their fully-qualified class names and all instance variables are recursively printed, which can make the output quite verbose! Here's a very small example spec:

```ruby
expected = hash_including(number: be_a(Numeric))
actual = {number: 4}
expect(actual).not_to match(expected)
```

which outputs the following diff:

```
                {
              -   number: #<RSpec::Matchers::BuiltIn::BeAKindOf:0x00000001062308f0 {
              -     @actual="not a number",
              -     @expected=Numeric
              -   }>
              +   number: "not a number"
                }
```

You can imagine this could get much longer with more complex expectations.

# Solution

Use the matcher's description on inspection. For the case above, this results in the following:

```
                {
              -   number: (be a kind of Numeric)
              +   number: "not a number"
                }
```