### PR TITLE
Remove instance_eval from InspectionTree

### DIFF
--- a/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_model.rb
+++ b/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_model.rb
@@ -8,27 +8,39 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text { |object| "#<#{object.class} " }
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<#{object.class} "
 
-                when_rendering_to_lines { add_text "{" }
-              end
-
-              nested do |object|
-                insert_separated_list(
-                  ["id"] + (object.attributes.keys.sort - ["id"])
-                ) do |name|
-                  as_prefix_when_rendering_to_lines { add_text "#{name}: " }
-
-                  add_inspection_of object.read_attribute(name)
+                # stree-ignore
+                t2.when_rendering_to_lines do |t3|
+                  t3.add_text "{"
                 end
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                when_rendering_to_lines { add_text "}" }
+              t1.nested do |t2|
+                t2.insert_separated_list(
+                  ["id"] + (object.attributes.keys.sort - ["id"])
+                ) do |t3, name|
+                  t3.as_prefix_when_rendering_to_lines do |t4|
+                    t4.add_text "#{name}: "
+                  end
 
-                add_text ">"
+                  t3.add_inspection_of object.read_attribute(name)
+                end
+              end
+
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                # stree-ignore
+                t2.when_rendering_to_lines do |t3|
+                  t3.add_text "}"
+                end
+
+                t2.add_text ">"
               end
             end
           end

--- a/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_relation.rb
+++ b/lib/super_diff/active_record/object_inspection/inspection_tree_builders/active_record_relation.rb
@@ -8,15 +8,24 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<ActiveRecord::Relation ["
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<ActiveRecord::Relation ["
               end
 
-              nested { |array| insert_array_inspection_of(array) }
+              # stree-ignore
+              t1.nested do |t2|
+                t2.insert_array_inspection_of(object)
+              end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text "]>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text "]>"
               end
             end
           end

--- a/lib/super_diff/active_support/object_inspection/inspection_tree_builders/hash_with_indifferent_access.rb
+++ b/lib/super_diff/active_support/object_inspection/inspection_tree_builders/hash_with_indifferent_access.rb
@@ -8,19 +8,34 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<HashWithIndifferentAccess {"
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<HashWithIndifferentAccess {"
               end
 
-              when_rendering_to_string { add_text " " }
+              # stree-ignore
+              t1.when_rendering_to_string do |t2|
+                t2.add_text " "
+              end
 
-              nested { |hash| insert_hash_inspection_of(hash) }
+              # stree-ignore
+              t1.nested do |t2|
+                t2.insert_hash_inspection_of(object)
+              end
 
-              when_rendering_to_string { add_text " " }
+              # stree-ignore
+              t1.when_rendering_to_string do |t2|
+                t2.add_text " "
+              end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text "}>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text "}>"
               end
             end
           end

--- a/lib/super_diff/active_support/object_inspection/inspection_tree_builders/ordered_options.rb
+++ b/lib/super_diff/active_support/object_inspection/inspection_tree_builders/ordered_options.rb
@@ -8,21 +8,34 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<OrderedOptions {"
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<OrderedOptions {"
               end
 
-              when_rendering_to_string { add_text " " }
-
-              nested do |ordered_options|
-                insert_hash_inspection_of(ordered_options.to_hash)
+              # stree-ignore
+              t1.when_rendering_to_string do |t2|
+                t2.add_text " "
               end
 
-              when_rendering_to_string { add_text " " }
+              # stree-ignore
+              t1.nested do |t2|
+                t2.insert_hash_inspection_of(object.to_hash)
+              end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text "}>"
+              # stree-ignore
+              t1.when_rendering_to_string do |t2|
+                t2.add_text " "
+              end
+
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text "}>"
               end
             end
           end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/array.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/array.rb
@@ -7,26 +7,45 @@ module SuperDiff
         end
 
         def call
-          empty = -> { object.empty? }
-          nonempty = -> { !object.empty? }
-
-          InspectionTree.new do
-            only_when empty do
-              as_lines_when_rendering_to_lines { add_text "[]" }
+          InspectionTree.new do |t1|
+            t1.only_when empty do |t2|
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines do |t3|
+                t3.add_text "[]"
+              end
             end
 
-            only_when nonempty do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "["
+            t1.only_when nonempty do |t2|
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t3|
+                t3.add_text "["
               end
 
-              nested { |array| insert_array_inspection_of(array) }
+              # stree-ignore
+              t2.nested do |t3|
+                t3.insert_array_inspection_of(object)
+              end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text "]"
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t3|
+                t3.add_text "]"
               end
             end
           end
+        end
+
+        private
+
+        def empty
+          -> { object.empty? }
+        end
+
+        def nonempty
+          -> { !object.empty? }
         end
       end
     end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/custom_object.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/custom_object.rb
@@ -7,21 +7,31 @@ module SuperDiff
         end
 
         def call
-          InspectionTree.new do
-            as_lines_when_rendering_to_lines(collection_bookend: :open) do
-              add_text { |object| "#<#{object.class} " }
+          InspectionTree.new do |t1|
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :open
+            ) do |t2|
+              t2.add_text "#<#{object.class} "
 
-              when_rendering_to_lines { add_text "{" }
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "{"
+              end
             end
 
-            nested do |object|
-              insert_hash_inspection_of(object.attributes_for_super_diff)
+            t1.nested do |t2|
+              t2.insert_hash_inspection_of(object.attributes_for_super_diff)
             end
 
-            as_lines_when_rendering_to_lines(collection_bookend: :close) do
-              when_rendering_to_lines { add_text "}" }
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :close
+            ) do |t2|
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "}"
+              end
 
-              add_text ">"
+              t2.add_text ">"
             end
           end
         end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/date_like.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/date_like.rb
@@ -7,31 +7,41 @@ module SuperDiff
         end
 
         def call
-          InspectionTree.new do
-            as_lines_when_rendering_to_lines(collection_bookend: :open) do
-              add_text { |date| "#<#{date.class} " }
+          InspectionTree.new do |t1|
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :open
+            ) do |t2|
+              t2.add_text "#<#{object.class} "
 
-              when_rendering_to_lines { add_text "{" }
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "{"
+              end
             end
 
-            when_rendering_to_string do
-              add_text { |date| date.strftime("%Y-%m-%d") }
+            t1.when_rendering_to_string do |t2|
+              t2.add_text object.strftime("%Y-%m-%d")
             end
 
-            when_rendering_to_lines do
-              nested do |date|
-                insert_separated_list(%i[year month day]) do |name|
-                  add_text name.to_s
-                  add_text ": "
-                  add_inspection_of date.public_send(name)
+            t1.when_rendering_to_lines do |t2|
+              t2.nested do |t3|
+                t3.insert_separated_list(%i[year month day]) do |t4, name|
+                  t4.add_text name.to_s
+                  t4.add_text ": "
+                  t4.add_inspection_of object.public_send(name)
                 end
               end
             end
 
-            as_lines_when_rendering_to_lines(collection_bookend: :close) do
-              when_rendering_to_lines { add_text "}" }
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :close
+            ) do |t2|
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "}"
+              end
 
-              add_text ">"
+              t2.add_text ">"
             end
           end
         end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/default_object.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/default_object.rb
@@ -7,46 +7,71 @@ module SuperDiff
         end
 
         def call
-          empty = -> { object.instance_variables.empty? }
-          nonempty = -> { !object.instance_variables.empty? }
-
-          InspectionTree.new do
-            only_when empty do
-              as_lines_when_rendering_to_lines do
-                add_text do |object|
+          InspectionTree.new do |t1|
+            t1.only_when empty do |t2|
+              t2.as_lines_when_rendering_to_lines do |t3|
+                t3.add_text(
                   "#<#{object.class.name}:" +
                     SuperDiff::Helpers.object_address_for(object) + ">"
-                end
+                )
               end
             end
 
-            only_when nonempty do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text do |object|
+            t1.only_when nonempty do |t2|
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t3|
+                t3.add_text(
                   "#<#{object.class.name}:" +
                     SuperDiff::Helpers.object_address_for(object)
-                end
+                )
 
-                when_rendering_to_lines { add_text " {" }
-              end
-
-              when_rendering_to_string { add_text " " }
-
-              nested do |object|
-                insert_separated_list(object.instance_variables.sort) do |name|
-                  as_prefix_when_rendering_to_lines { add_text "#{name}=" }
-
-                  add_inspection_of object.instance_variable_get(name)
+                # stree-ignore
+                t3.when_rendering_to_lines do |t4|
+                  t4.add_text " {"
                 end
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                when_rendering_to_lines { add_text "}" }
+              # stree-ignore
+              t2.when_rendering_to_string do |t3|
+                t3.add_text " "
+              end
 
-                add_text ">"
+              t2.nested do |t3|
+                t3.insert_separated_list(
+                  object.instance_variables.sort
+                ) do |t4, name|
+                  # stree-ignore
+                  t4.as_prefix_when_rendering_to_lines do |t5|
+                    t5.add_text "#{name}="
+                  end
+
+                  t4.add_inspection_of object.instance_variable_get(name)
+                end
+              end
+
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t3|
+                # stree-ignore
+                t3.when_rendering_to_lines do |t4|
+                  t4.add_text "}"
+                end
+
+                t3.add_text ">"
               end
             end
           end
+        end
+
+        private
+
+        def empty
+          -> { object.instance_variables.empty? }
+        end
+
+        def nonempty
+          -> { !object.instance_variables.empty? }
         end
       end
     end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/hash.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/hash.rb
@@ -7,30 +7,55 @@ module SuperDiff
         end
 
         def call
-          empty = -> { object.empty? }
-          nonempty = -> { !object.empty? }
-
-          InspectionTree.new do
-            only_when empty do
-              as_lines_when_rendering_to_lines { add_text "{}" }
+          InspectionTree.new do |t1|
+            t1.only_when empty do |t2|
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines do |t3|
+                t3.add_text "{}"
+              end
             end
 
-            only_when nonempty do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "{"
+            t1.only_when nonempty do |t2|
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t3|
+                t3.add_text "{"
               end
 
-              when_rendering_to_string { add_text " " }
+              # stree-ignore
+              t2.when_rendering_to_string do |t3|
+                t3.add_text " "
+              end
 
-              nested { |hash| insert_hash_inspection_of(hash) }
+              # stree-ignore
+              t2.nested do |t3|
+                t3.insert_hash_inspection_of(object)
+              end
 
-              when_rendering_to_string { add_text " " }
+              # stree-ignore
+              t2.when_rendering_to_string do |t3|
+                t3.add_text " "
+              end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text "}"
+              # stree-ignore
+              t2.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t3|
+                t3.add_text "}"
               end
             end
           end
+        end
+
+        private
+
+        def empty
+          -> { object.empty? }
+        end
+
+        def nonempty
+          -> { !object.empty? }
         end
       end
     end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/primitive.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/primitive.rb
@@ -7,11 +7,9 @@ module SuperDiff
         end
 
         def call
-          InspectionTree.new do
-            as_lines_when_rendering_to_lines do
-              # rubocop:disable Style/SymbolProc
-              add_text { |object| object.inspect }
-              # rubocop:enable Style/SymbolProc
+          InspectionTree.new do |t1|
+            t1.as_lines_when_rendering_to_lines do |t2|
+              t2.add_text object.inspect
             end
           end
         end

--- a/lib/super_diff/object_inspection/inspection_tree_builders/time_like.rb
+++ b/lib/super_diff/object_inspection/inspection_tree_builders/time_like.rb
@@ -7,37 +7,48 @@ module SuperDiff
         end
 
         def call
-          InspectionTree.new do
-            as_lines_when_rendering_to_lines(collection_bookend: :open) do
-              add_text { |time| "#<#{time.class} " }
+          InspectionTree.new do |t1|
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :open
+            ) do |t2|
+              t2.add_text "#<#{object.class} "
 
-              when_rendering_to_lines { add_text "{" }
-            end
-
-            when_rendering_to_string do
-              add_text do |time|
-                time.strftime("%Y-%m-%d %H:%M:%S") +
-                  (time.subsec == 0 ? "" : "+#{time.subsec.inspect}") + " " +
-                  time.strftime("%:z") + (time.zone ? " (#{time.zone})" : "")
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "{"
               end
             end
 
-            when_rendering_to_lines do
-              nested do |time|
-                insert_separated_list(
+            t1.when_rendering_to_string do |t2|
+              t2.add_text(
+                object.strftime("%Y-%m-%d %H:%M:%S") +
+                  (object.subsec == 0 ? "" : "+#{object.subsec.inspect}") +
+                  " " + object.strftime("%:z") +
+                  (object.zone ? " (#{object.zone})" : "")
+              )
+            end
+
+            t1.when_rendering_to_lines do |t2|
+              t2.nested do |t3|
+                t3.insert_separated_list(
                   %i[year month day hour min sec subsec zone utc_offset]
-                ) do |name|
-                  add_text name.to_s
-                  add_text ": "
-                  add_inspection_of time.public_send(name)
+                ) do |t4, name|
+                  t4.add_text name.to_s
+                  t4.add_text ": "
+                  t4.add_inspection_of object.public_send(name)
                 end
               end
             end
 
-            as_lines_when_rendering_to_lines(collection_bookend: :close) do
-              when_rendering_to_lines { add_text "}" }
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :close
+            ) do |t2|
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "}"
+              end
 
-              add_text ">"
+              t2.add_text ">"
             end
           end
         end

--- a/lib/super_diff/object_inspection/nodes/as_lines_when_rendering_to_lines.rb
+++ b/lib/super_diff/object_inspection/nodes/as_lines_when_rendering_to_lines.rb
@@ -15,9 +15,10 @@ module SuperDiff
           *args,
           add_comma: false,
           collection_bookend: nil,
-          **rest
+          **rest,
+          &block
         )
-          super(tree, *args, **rest)
+          super(tree, *args, **rest, &block)
 
           @add_comma = add_comma
           @collection_bookend = collection_bookend

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/collection_containing_exactly.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/collection_containing_exactly.rb
@@ -8,17 +8,24 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<a collection containing exactly ("
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<a collection containing exactly ("
               end
 
-              nested do |aliased_matcher|
-                insert_array_inspection_of(aliased_matcher.expected)
+              # stree-ignore
+              t1.nested do |t2|
+                t2.insert_array_inspection_of(object.expected)
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text ")>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text ")>"
               end
             end
           end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/collection_including.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/collection_including.rb
@@ -9,23 +9,29 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<a collection including ("
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<a collection including ("
               end
 
-              nested do |value|
-                array =
-                  if SuperDiff::RSpec.a_collection_including_something?(value)
-                    value.expecteds
-                  else
-                    value.instance_variable_get(:@expected)
-                  end
-                insert_array_inspection_of(array)
+              t1.nested do |t2|
+                if SuperDiff::RSpec.a_collection_including_something?(object)
+                  t2.insert_array_inspection_of(object.expecteds)
+                else
+                  t2.insert_array_inspection_of(
+                    object.instance_variable_get(:@expected)
+                  )
+                end
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text ")>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text ")>"
               end
             end
           end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/hash_including.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/hash_including.rb
@@ -9,24 +9,29 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<a hash including ("
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<a hash including ("
               end
 
-              nested do |value|
-                hash =
-                  if SuperDiff::RSpec.a_hash_including_something?(value)
-                    value.expecteds.first
-                  else
-                    value.instance_variable_get(:@expected)
-                  end
-
-                insert_hash_inspection_of(hash)
+              t1.nested do |t2|
+                if SuperDiff::RSpec.a_hash_including_something?(object)
+                  t2.insert_hash_inspection_of(object.expecteds.first)
+                else
+                  t2.insert_hash_inspection_of(
+                    object.instance_variable_get(:@expected)
+                  )
+                end
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text ")>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text ")>"
               end
             end
           end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/instance_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/instance_of.rb
@@ -9,16 +9,15 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text do |value|
-                klass =
-                  if SuperDiff::RSpec.an_instance_of_something?(value)
-                    value.expected
-                  else
-                    value.instance_variable_get(:@klass)
-                  end
-                "#<an instance of #{klass}>"
-              end
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              klass =
+                if SuperDiff::RSpec.an_instance_of_something?(object)
+                  object.expected
+                else
+                  object.instance_variable_get(:@klass)
+                end
+
+              t1.add_text "#<an instance of #{klass}>"
             end
           end
         end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/kind_of.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/kind_of.rb
@@ -9,16 +9,15 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text do |value|
-                klass =
-                  if SuperDiff::RSpec.a_kind_of_something?(value)
-                    value.expected
-                  else
-                    value.instance_variable_get(:@klass)
-                  end
-                "#<a kind of #{klass}>"
-              end
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              klass =
+                if SuperDiff::RSpec.a_kind_of_something?(object)
+                  object.expected
+                else
+                  object.instance_variable_get(:@klass)
+                end
+
+              t1.add_text "#<a kind of #{klass}>"
             end
           end
         end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/object_having_attributes.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/object_having_attributes.rb
@@ -8,17 +8,24 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_lines_when_rendering_to_lines(collection_bookend: :open) do
-                add_text "#<an object having attributes ("
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :open
+              ) do |t2|
+                t2.add_text "#<an object having attributes ("
               end
 
-              nested do |aliased_matcher|
-                insert_hash_inspection_of(aliased_matcher.expected)
+              # stree-ignore
+              t1.nested do |t2|
+                t2.insert_hash_inspection_of(object.expected)
               end
 
-              as_lines_when_rendering_to_lines(collection_bookend: :close) do
-                add_text ")>"
+              # stree-ignore
+              t1.as_lines_when_rendering_to_lines(
+                collection_bookend: :close
+              ) do |t2|
+                t2.add_text ")>"
               end
             end
           end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/rspec_matcher.rb
@@ -9,8 +9,8 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              add_text { |object| "#<#{object.description}>" }
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              t1.add_text "#<#{object.description}>"
             end
           end
         end

--- a/lib/super_diff/rspec/object_inspection/inspection_tree_builders/value_within.rb
+++ b/lib/super_diff/rspec/object_inspection/inspection_tree_builders/value_within.rb
@@ -8,22 +8,21 @@ module SuperDiff
           end
 
           def call
-            SuperDiff::ObjectInspection::InspectionTree.new do
-              as_prelude_when_rendering_to_lines do
-                add_text "#<a value within "
+            SuperDiff::ObjectInspection::InspectionTree.new do |t1|
+              t1.as_prelude_when_rendering_to_lines do |t2|
+                t2.add_text "#<a value within "
 
-                add_inspection_of as_lines: false do |aliased_matcher|
-                  aliased_matcher.base_matcher.instance_variable_get("@delta")
-                end
+                t2.add_inspection_of(
+                  object.base_matcher.instance_variable_get("@delta"),
+                  as_lines: false
+                )
 
-                add_text " of "
+                t2.add_text " of "
               end
 
-              # rubocop:disable Style/SymbolProc
-              add_inspection_of { |aliased_matcher| aliased_matcher.expected }
-              # rubocop:enable Style/SymbolProc
+              t1.add_inspection_of object.expected
 
-              add_text ">"
+              t1.add_text ">"
             end
           end
         end


### PR DESCRIPTION
The InspectionTree class defines methods that create nodes in the tree. Some of these methods take a block which is `instance_eval`'ed inside of a new subtree. This use of `instance_eval` may seem to create a very clean and easy to use API on the surface, but it quickly breaks down if, as you are defining your InspectionTree, you need to extract methods inside of your InspectionTreeBuilder and then reference them. _Not_ `instance_eval`'ing creates footguns, but it also removes the magic and mystery around how InspectionTree works.