### PR TITLE
Fix Zeus

### DIFF
--- a/config/zeus_plan.rb
+++ b/config/zeus_plan.rb
@@ -14,22 +14,24 @@ class CustomZeusPlan < Zeus::Plan
     :boot_active_support,
     :boot_active_record,
     :boot_rails,
+    :boot_rails_engine_with_action_controller,
     :run_plain_test,
     :run_rspec_active_support_test,
     :run_rspec_active_record_test,
-    :run_rspec_rails_test
+    :run_rspec_rails_test,
+    :run_rspec_rails_engine_with_action_controller_test
   )
 
   def initialize(
     using_outside_of_zeus: false,
     color_enabled: false,
-    configuration: {}
+    super_diff_configuration: {}
   )
     @test_plan =
       TestPlan.new(
         using_outside_of_zeus: using_outside_of_zeus,
         color_enabled: color_enabled,
-        configuration: configuration
+        super_diff_configuration: super_diff_configuration
       )
   end
 end

--- a/spec/integration/rails/engines_spec.rb
+++ b/spec/integration/rails/engines_spec.rb
@@ -1,15 +1,20 @@
 require "spec_helper"
 
-RSpec.describe "Integration with Rails engines", type: :integration do
+RSpec.describe "Integration with Rails engines",
+               type: :integration,
+               active_support: true do
   context "when ActiveRecord is not loaded via Combustion" do
     it "does not fail to load" do
       as_both_colored_and_uncolored do |color_enabled|
         program =
-          make_rspec_rails_engine_program(
+          make_rspec_rails_engine_with_action_controller_program(
             "expect(true).to be(true)",
-            combustion_initialize: [:action_controller],
             color_enabled: color_enabled
           )
+
+        expect(program).to produce_output_when_run(
+          "1 example, 0 failures"
+        ).in_color(color_enabled)
 
         expect(program).not_to produce_output_when_run(
           "uninitialized constant ActiveRecord"

--- a/spec/support/integration/helpers.rb
+++ b/spec/support/integration/helpers.rb
@@ -9,13 +9,13 @@ module SuperDiff
     def make_plain_test_program(
       test,
       color_enabled:,
-      configuration: {},
+      super_diff_configuration: {},
       preserve_as_whole_file: false
     )
       TestPrograms::Plain.new(
         test,
         color_enabled: color_enabled,
-        configuration: configuration,
+        super_diff_configuration: super_diff_configuration,
         preserve_as_whole_file: preserve_as_whole_file
       )
     end
@@ -32,15 +32,13 @@ module SuperDiff
       TestPrograms::RSpecRails.new(test, color_enabled: color_enabled)
     end
 
-    def make_rspec_rails_engine_program(
+    def make_rspec_rails_engine_with_action_controller_program(
       test,
-      color_enabled:,
-      combustion_initialize:
+      color_enabled:
     )
-      TestPrograms::RspecRailsEngine.new(
+      TestPrograms::RspecRailsEngineWithActionController.new(
         test,
-        color_enabled: color_enabled,
-        combustion_initialize: combustion_initialize
+        color_enabled: color_enabled
       )
     end
 

--- a/spec/support/integration/test_programs/base.rb
+++ b/spec/support/integration/test_programs/base.rb
@@ -13,12 +13,12 @@ module SuperDiff
         def initialize(
           code,
           color_enabled:,
-          configuration: {},
+          super_diff_configuration: {},
           preserve_as_whole_file: false
         )
           @code = code.strip
           @color_enabled = color_enabled
-          @configuration = configuration
+          @super_diff_configuration = super_diff_configuration
           @preserve_as_whole_file = preserve_as_whole_file
         end
 
@@ -38,7 +38,7 @@ module SuperDiff
 
         private
 
-        attr_reader :code, :configuration
+        attr_reader :code, :super_diff_configuration
 
         def color_enabled?
           @color_enabled
@@ -74,8 +74,8 @@ module SuperDiff
               color_option,
               "--no-pry",
               tempfile.to_s,
-              "--configuration",
-              JSON.generate(configuration)
+              "--super-diff-configuration",
+              JSON.generate(super_diff_configuration)
             ]
           else
             ["rspec", "--options", "/tmp/dummy-rspec-config", tempfile.to_s]
@@ -110,7 +110,7 @@ module SuperDiff
               test_plan = TestPlan.new(
                 using_outside_of_zeus: true,
                 color_enabled: #{color_enabled?.inspect},
-                configuration: #{configuration.inspect}
+                super_diff_configuration: #{super_diff_configuration.inspect}
               )
               #{test_plan_prelude}
               test_plan.#{test_plan_command}

--- a/spec/support/integration/test_programs/rspec_rails_engine.rb
+++ b/spec/support/integration/test_programs/rspec_rails_engine.rb
@@ -1,29 +1,19 @@
 module SuperDiff
   module IntegrationTests
     module TestPrograms
-      class RspecRailsEngine < Base
-        def initialize(*args, combustion_initialize:, **options)
-          super(*args, **options)
-          @combustion_initialize = combustion_initialize
-        end
-
+      class RspecRailsEngineWithActionController < Base
         protected
 
         def test_plan_prelude
           <<~PRELUDE.strip
-            test_plan.boot_rails_engine(
-              combustion_initialize: #{combustion_initialize.inspect}
-            )
+            test_plan.boot
+            test_plan.boot_rails_engine_with_action_controller
           PRELUDE
         end
 
         def test_plan_command
           "run_rspec_rails_test"
         end
-
-        private
-
-        attr_reader :combustion_initialize
       end
     end
   end

--- a/spec/support/shared_examples/elided_diffs.rb
+++ b/spec/support/shared_examples/elided_diffs.rb
@@ -40,7 +40,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: true,
                 diff_elision_maximum: 3
               }
@@ -129,7 +129,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: false,
                 diff_elision_maximum: 3
               }
@@ -228,7 +228,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: true,
                 diff_elision_maximum: 3
               }
@@ -318,7 +318,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: false,
                 diff_elision_maximum: 3
               }
@@ -550,7 +550,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: true,
                 diff_elision_maximum: 10
               }
@@ -811,7 +811,7 @@ shared_examples_for "a matcher that supports elided diffs" do
             make_plain_test_program(
               snippet,
               color_enabled: color_enabled,
-              configuration: {
+              super_diff_configuration: {
                 diff_elision_enabled: false,
                 diff_elision_maximum: 10
               }

--- a/spec/support/shared_examples/key.rb
+++ b/spec/support/shared_examples/key.rb
@@ -19,7 +19,7 @@ shared_examples_for "a matcher that supports a toggleable key" do
           make_plain_test_program(
             snippet,
             color_enabled: color_enabled,
-            configuration: {
+            super_diff_configuration: {
               key_enabled: true
             }
           )
@@ -80,7 +80,7 @@ shared_examples_for "a matcher that supports a toggleable key" do
           make_plain_test_program(
             snippet,
             color_enabled: color_enabled,
-            configuration: {
+            super_diff_configuration: {
               key_enabled: false
             }
           )

--- a/zeus.json
+++ b/zeus.json
@@ -11,8 +11,10 @@
       },
       "boot_rails": {
         "run_rspec_rails_test": []
+      },
+      "boot_rails_engine_with_action_controller": {
+        "run_rspec_rails_engine_with_action_controller_test": []
       }
-    },
-    "boot_rails_engine": []
+    }
   }
 }


### PR DESCRIPTION
The Zeus config has been broken since integration tests for Rails engines were added. It appears that the Zeus boot step responsible for loading Combustion was passing an empty array for the modules to initialize. Outside of Zeus, the integration test customizes this array, but inside Zeus, that never happens, and there isn't a way to do that. So, considering that we only have one engine-specific integration test, I removed the customization option and hardcoded the list of modules, renaming the boot step and corresponding command to match. I then corrected the test accordingly.