### PR TITLE
Use Zeus to run integration tests on CI

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -103,5 +103,16 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+      - name: Install Zeus
+        run: gem install zeus
+      - name: Start Zeus
+        uses: JarvusInnovations/background-action@v1
+        with:
+          run: zeus start
+          wait-on: |
+            socket:.zeus.sock
+            file:.zeus.sock
+          wait-for: 15s
+          log-output-if: failure
       - name: Run tests
         run: bundle exec rake --trace


### PR DESCRIPTION
This vastly decreases the amount of time it takes to run CI. For instance, the "Run tests" job in a single workflow goes from ~7 minutes to ~1.75 minutes.