### PR TITLE
Fix match_array to truly accept non-array

### DIFF
--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -803,7 +803,14 @@ module RSpec
       end
 
       def match_array(items)
-        BuiltIn::MatchArray.new(items.is_a?(String) ? [items] : items)
+        # This is a bit strange, but this is fundamentally different from
+        # splatting `items` in the argument list. It's functionally equivalent
+        # to, though not quite the same as:
+        #
+        #     items.is_a?(Array) ? items : [items]
+        #
+        items = *items
+        BuiltIn::MatchArray.new(items)
       end
     end
   end

--- a/spec/integration/rspec/match_array_matcher_spec.rb
+++ b/spec/integration/rspec/match_array_matcher_spec.rb
@@ -379,12 +379,12 @@ RSpec.describe "Integration with RSpec's #match_array matcher",
     end
   end
 
-  context "when the input value is a string" do
-    it "produces the correct failure message when used in the positive" do
+  context "when the input value is not an array, and especially not a value that could be turned into one" do
+    fit "produces the correct failure message, as though an array had been given" do
       as_both_colored_and_uncolored do |color_enabled|
         snippet = <<~TEST.strip
-          actual = ["Marty", "Jennifer", "Doc"]
-          expected = "Einie"
+          actual = [:marty, :jennifer, :doc]
+          expected = :einie
           expect(actual).to match_array(expected)
         TEST
         program = make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -397,20 +397,20 @@ RSpec.describe "Integration with RSpec's #match_array matcher",
               proc do
                 line do
                   plain "Expected "
-                  actual %|["Marty", "Jennifer", "Doc"]|
+                  actual "[:marty, :jennifer, :doc]"
                   plain " to match array with "
-                  expected %|"Einie"|
+                  expected ":einie"
                   plain "."
                 end
               end,
             diff:
               proc do
                 plain_line "  ["
-                actual_line %|+   "Marty",|
-                actual_line %|+   "Jennifer",|
-                actual_line %|+   "Doc",|
-                # expected_line %|-   "Einie"|  # TODO
-                expected_line %|-   "Einie",|
+                actual_line "+   :marty,"
+                actual_line "+   :jennifer,"
+                actual_line "+   :doc,"
+                # expected_line %|-   :einie|  # TODO
+                expected_line "-   :einie,"
                 plain_line "  ]"
               end
           )


### PR DESCRIPTION
Previously, it was noticed that `match_array` raised an error when given a single, non-array argument as opposed to an array (which is the documented usage). An attempt was made to fix this; however, the conditional added to `match_array` only checked that the single argument was a string. This commit matches the original implementation of `match_array` by accepting any type of non-array, not just a string.

---

Also see: https://github.com/mcmire/super_diff/issues/97

Recreation of: https://github.com/mcmire/super_diff/pull/135 (hat tip: @wata727)