### PR TITLE
Revert "Use Zeus to run integration tests on CI (#212)"

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -103,16 +103,5 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: Install Zeus
-        run: gem install zeus
-      - name: Start Zeus
-        uses: JarvusInnovations/background-action@v1
-        with:
-          run: zeus start
-          wait-on: |
-            socket:.zeus.sock
-            file:.zeus.sock
-          wait-for: 15s
-          log-output-if: failure
       - name: Run tests
         run: bundle exec rake --trace

--- a/lib/super_diff/differs/main.rb
+++ b/lib/super_diff/differs/main.rb
@@ -6,7 +6,10 @@ module SuperDiff
       method_object(:expected, :actual, [indent_level: 0, omit_empty: false])
 
       def call
-        pp available_classes: available_classes
+        pp expected: expected,
+           actual: actual,
+           available_classes: available_classes,
+           resolved_class: resolved_class
 
         if resolved_class
           resolved_class.call(expected, actual, indent_level: indent_level)

--- a/lib/super_diff/differs/main.rb
+++ b/lib/super_diff/differs/main.rb
@@ -6,6 +6,8 @@ module SuperDiff
       method_object(:expected, :actual, [indent_level: 0, omit_empty: false])
 
       def call
+        pp available_classes: available_classes
+
         if resolved_class
           resolved_class.call(expected, actual, indent_level: indent_level)
         else

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -14,8 +14,9 @@ module SuperDiff
         else
           ""
         end
-        # rescue SuperDiff::Errors::NoDifferAvailableError
-        # ""
+      rescue SuperDiff::Errors::NoDifferAvailableError => error
+        puts "Got error: #{error}"
+        ""
       end
 
       private

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -16,6 +16,7 @@ module SuperDiff
         end
       rescue SuperDiff::Errors::NoDifferAvailableError => error
         puts "Got error: #{error}"
+        pp expected: expected, actual: actual
         ""
       end
 

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -20,6 +20,10 @@ module SuperDiff
       private
 
       def worth_diffing?
+        pp comparing_inequal_values: comparing_inequal_values?,
+           comparing_primitive_values: comparing_primitive_values?,
+           comparing_singleline_strings: comparing_singleline_strings?
+
         comparing_inequal_values? && !comparing_primitive_values? &&
           !comparing_singleline_strings?
       end

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -9,12 +9,13 @@ module SuperDiff
         if worth_diffing?
           diff =
             SuperDiff::Differs::Main.call(expected, actual, omit_empty: true)
+          pp diff: diff
           "\n\n" + diff
         else
           ""
         end
-      rescue SuperDiff::Errors::NoDifferAvailableError
-        ""
+        # rescue SuperDiff::Errors::NoDifferAvailableError
+        # ""
       end
 
       private

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -710,7 +710,9 @@ module RSpec
 
       class MatchArray < ContainExactly
         def expected_for_diff
-          matchers.an_array_matching(expected)
+          value = matchers.an_array_matching(expected)
+          pp an_array_matching: value
+          value
         end
 
         def expected_action_for_matcher_text
@@ -799,6 +801,7 @@ module RSpec
 
     SuperDiff.insert_overrides(self) do
       def self.prepended(base)
+        puts "Yay, prepended was called!"
         base.class_eval { alias_matcher :an_array_matching, :match_array }
       end
 
@@ -812,6 +815,9 @@ module RSpec
         items = *items
         BuiltIn::MatchArray.new(items)
       end
+      # ::RSpec::Matchers.alias_matcher :an_array_matching, :match_array # do |desc|
+      # desc.sub("contain exactly", "an array containing exactly")
+      # end
     end
 
     p ancestors: ancestors

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -822,6 +822,6 @@ module RSpec
 
     p ancestors: ancestors
 
-    alias_matcher :an_array_matching, :match_array
+    # alias_matcher :an_array_matching, :match_array
   end
 end

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -800,10 +800,10 @@ module RSpec
     end
 
     SuperDiff.insert_overrides(self) do
-      def self.prepended(base)
-        puts "Yay, prepended was called!"
-        base.class_eval { alias_matcher :an_array_matching, :match_array }
-      end
+      # def self.prepended(base)
+      # puts "Yay, prepended was called!"
+      # base.class_eval { alias_matcher :an_array_matching, :match_array }
+      # end
 
       def match_array(items)
         # This is a bit strange, but this is fundamentally different from
@@ -815,11 +815,13 @@ module RSpec
         items = *items
         BuiltIn::MatchArray.new(items)
       end
-      # ::RSpec::Matchers.alias_matcher :an_array_matching, :match_array # do |desc|
+      # ::RSpec::Matchers.
       # desc.sub("contain exactly", "an array containing exactly")
       # end
     end
 
     p ancestors: ancestors
+
+    alias_matcher :an_array_matching, :match_array
   end
 end

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -813,5 +813,7 @@ module RSpec
         BuiltIn::MatchArray.new(items)
       end
     end
+
+    p ancestors: ancestors
   end
 end

--- a/spec/support/command_runner.rb
+++ b/spec/support/command_runner.rb
@@ -244,7 +244,8 @@ Output:
   end
 
   def debugging_enabled?
-    ENV["DEBUG_COMMANDS"] == "1"
+    # ENV["DEBUG_COMMANDS"] == "1"
+    true
   end
 
   def debug


### PR DESCRIPTION
This reverts commit 9e461603c205a6de7d2fa1ceb40db8022a56947d.

Unfortunately, Zeus is just not reliable enough to run on CI. It's not even reliable locally. Sometimes tests will hang for no reason, and sometimes Zeus will fail with errors like `read unix ->: recvmsg: message too long`. And unfortunately, once Zeus fails, the best way to fix it is to restart it. This isn't possible to do in CI tests, and adding some kind of "with Zeus, then without Zeus" strategy to tests would add complexity I don't want. I'll have to find a better way.