### PR TITLE
Improve raise_error messages

### DIFF
--- a/lib/super_diff/rspec/matcher_text_builders/raise_error.rb
+++ b/lib/super_diff/rspec/matcher_text_builders/raise_error.rb
@@ -5,14 +5,10 @@ module SuperDiff
         protected
 
         def actual_phrase
-          actual ? "Expected raised exception" : "Expected"
-        end
-
-        def add_actual_value
-          if actual
-            template.add_text_in_color(actual_color) { actual }
+          if actual == "exception-free block"
+            "Expected"
           else
-            template.add_text("block")
+            "Expected raised exception"
           end
         end
       end

--- a/spec/integration/rspec/raise_error_matcher_spec.rb
+++ b/spec/integration/rspec/raise_error_matcher_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
   context "given only an exception class" do
     context "when used in the positive" do
       context "when the block raises a different error than what is given" do
-        context "when the message is short" do
+        context "when the actual message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -25,7 +25,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                         plain "Expected raised exception "
                         actual %|#<StandardError "boo">|
                         plain " to match "
-                        expected "#<RuntimeError>"
+                        expected "a kind of RuntimeError"
                         plain "."
                       end
                     end
@@ -38,7 +38,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the actual message is long" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -62,7 +62,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                       line do
                         plain "                 to match "
-                        expected "#<RuntimeError>"
+                        expected "a kind of RuntimeError"
                       end
                     end
                 )
@@ -91,8 +91,10 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                 expectation:
                   proc do
                     line do
-                      plain "Expected block to raise error "
-                      expected "#<RuntimeError>"
+                      plain "Expected "
+                      actual "exception-free block"
+                      plain " to raise "
+                      expected "a kind of RuntimeError"
                       plain "."
                     end
                   end
@@ -107,7 +109,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
 
     context "when used in the negative" do
-      context "when the message is short" do
+      context "when the actual message is short" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -127,7 +129,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                       plain "Expected raised exception "
                       actual %|#<StandardError "boo">|
                       plain " not to match "
-                      expected "#<StandardError>"
+                      expected "a kind of StandardError"
                       plain "."
                     end
                   end
@@ -140,7 +142,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
         end
       end
 
-      context "when the message is long" do
+      context "when the actual message is long" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -164,7 +166,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                     line do
                       plain "             not to match "
-                      expected "#<StandardError>"
+                      expected "a kind of StandardError"
                     end
                   end
               )
@@ -178,10 +180,10 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
   end
 
-  context "with only a message (and assuming a RuntimeError)" do
+  context "given only a string message" do
     context "when used in the positive" do
       context "when the block raises a different error than what is given" do
-        context "when the message is short" do
+        context "when the expected and/or actual message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -200,7 +202,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                         plain "Expected raised exception "
                         actual %|#<RuntimeError "boo">|
                         plain " to match "
-                        expected %|#<Exception "hell">|
+                        expected %|a kind of Exception with message "hell"|
                         plain "."
                       end
                     end
@@ -213,7 +215,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the expected and/or actual message is long" do
           context "but contains no line breaks" do
             it "produces the correct failure message when used in the positive" do
               as_both_colored_and_uncolored do |color_enabled|
@@ -240,7 +242,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                         line do
                           plain "                 to match "
-                          expected %|#<Exception "whatever">|
+                          expected %|a kind of Exception with message "whatever"|
                         end
                       end
                   )
@@ -283,7 +285,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                         line do
                           plain "                 to match "
-                          expected %|#<Exception "This is fun\\nAnd so is this">|
+                          expected %|a kind of Exception with message "This is fun\\nAnd so is this"|
                         end
                       end,
                     diff:
@@ -304,7 +306,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
       end
 
       context "when the block raises no error" do
-        context "when the message is short" do
+        context "when the expected message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -320,8 +322,10 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                   expectation:
                     proc do
                       line do
-                        plain "Expected block to raise error "
-                        expected %|#<Exception "hell">|
+                        plain "Expected "
+                        actual "exception-free block"
+                        plain " to raise "
+                        expected %|a kind of Exception with message "hell"|
                         plain "."
                       end
                     end
@@ -334,7 +338,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the expected message is long" do
           context "but contains no line breaks" do
             it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
@@ -352,14 +356,15 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                     newline_before_expectation: true,
                     expectation:
                       proc do
+                        # stree-ignore
                         line do
-                          plain "      Expected "
-                          plain "block"
+                          plain "Expected "
+                          actual "exception-free block"
                         end
 
                         line do
-                          plain "to raise error "
-                          expected %|#<Exception "this is a super super super super super super long message">|
+                          plain "to raise "
+                          expected %|a kind of Exception with message "this is a super super super super super super long message"|
                         end
                       end
                   )
@@ -372,11 +377,15 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
 
           context "but contains line breaks" do
-            it "produces the correct failure message when used in the negative" do
+            it "produces the correct failure message" do
               as_both_colored_and_uncolored do |color_enabled|
                 snippet = <<~TEST.strip
-                  message = "some really long message"
-                  expect { raise(message) }.not_to raise_error(message)
+                  expected_message = <<\~MESSAGE.rstrip
+                    this is a super super
+                    super super super
+                    super long message
+                  MESSAGE
+                  expect { }.to raise_error(expected_message)
                 TEST
                 program =
                   make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -384,19 +393,19 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                 expected_output =
                   build_expected_output(
                     color_enabled: color_enabled,
-                    snippet:
-                      "expect { raise(message) }.not_to raise_error(message)",
+                    snippet: "expect { }.to raise_error(expected_message)",
                     newline_before_expectation: true,
                     expectation:
                       proc do
+                        # stree-ignore
                         line do
-                          plain "Expected raised exception "
-                          actual %|#<RuntimeError "some really long message">|
+                          plain "Expected "
+                          actual "exception-free block"
                         end
 
                         line do
-                          plain "             not to match "
-                          expected %|#<Exception "some really long message">|
+                          plain "to raise "
+                          expected %|a kind of Exception with message "this is a super super\\nsuper super super\\nsuper long message"|
                         end
                       end
                   )
@@ -412,7 +421,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
 
     context "when used in the negative" do
-      context "when the message is short" do
+      context "when the expected and/or actual message is short" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -431,7 +440,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                       plain "Expected raised exception "
                       actual %|#<RuntimeError "boo">|
                       plain " not to match "
-                      expected %|#<Exception "boo">|
+                      expected %|a kind of Exception with message "boo"|
                       plain "."
                     end
                   end
@@ -444,7 +453,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
         end
       end
 
-      context "when the message is long" do
+      context "when the expected and/or actual message is long" do
         context "but contains no line breaks" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
@@ -470,7 +479,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                       line do
                         plain "             not to match "
-                        expected %|#<Exception "some really long message">|
+                        expected %|a kind of Exception with message "some really long message"|
                       end
                     end
                 )
@@ -487,8 +496,9 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
                 message = <<\~MESSAGE.rstrip
-                  This is fun
-                  So is this
+                  this is a super super
+                  super super super
+                  super long message
                 MESSAGE
                 expect { raise(message) }.not_to raise_error(message)
               TEST
@@ -505,12 +515,12 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                     proc do
                       line do
                         plain "Expected raised exception "
-                        actual %|#<RuntimeError "This is fun\\nSo is this">|
+                        actual %|#<RuntimeError "this is a super super\\nsuper super super\\nsuper long message">|
                       end
 
                       line do
                         plain "             not to match "
-                        expected %|#<Exception "This is fun\\nSo is this">|
+                        expected %|a kind of Exception with message "this is a super super\\nsuper super super\\nsuper long message"|
                       end
                     end
                 )
@@ -525,10 +535,154 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
   end
 
-  context "with both an exception and a message" do
+  context "given only a regexp message" do
     context "when used in the positive" do
       context "when the block raises a different error than what is given" do
-        context "when the message is short" do
+        it "produces the correct failure message" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+                expect { raise 'boo' }.to raise_error(/hell/i)
+            TEST
+            program =
+              make_plain_test_program(snippet, color_enabled: color_enabled)
+
+            expected_output =
+              build_expected_output(
+                color_enabled: color_enabled,
+                snippet: "expect { raise 'boo' }.to raise_error(/hell/i)",
+                newline_before_expectation: true,
+                expectation:
+                  proc do
+                    line do
+                      plain "Expected raised exception "
+                      actual %|#<RuntimeError "boo">|
+                    end
+
+                    line do
+                      plain "                 to match "
+                      expected "a kind of Exception with message matching /hell/i"
+                    end
+                  end
+              )
+
+            expect(program).to produce_output_when_run(
+              expected_output
+            ).in_color(color_enabled)
+          end
+        end
+      end
+
+      context "when the block raises no error" do
+        context "when the expected message is short" do
+          it "produces the correct failure message" do
+            as_both_colored_and_uncolored do |color_enabled|
+              snippet = <<~TEST.strip
+                expect { }.to raise_error(/hell/i)
+              TEST
+              program =
+                make_plain_test_program(snippet, color_enabled: color_enabled)
+
+              expected_output =
+                build_expected_output(
+                  color_enabled: color_enabled,
+                  snippet: "expect { }.to raise_error(/hell/i)",
+                  expectation:
+                    proc do
+                      line do
+                        plain "Expected "
+                        actual "exception-free block"
+                        plain " to raise "
+                        expected "a kind of Exception with message matching /hell/i"
+                        plain "."
+                      end
+                    end
+                )
+
+              expect(program).to produce_output_when_run(
+                expected_output
+              ).in_color(color_enabled)
+            end
+          end
+        end
+
+        context "when the expected message is long" do
+          it "produces the correct failure message" do
+            as_both_colored_and_uncolored do |color_enabled|
+              snippet = <<~TEST.strip
+                expect { }.to raise_error(/this is a super super super super super super long message/i)
+              TEST
+              program =
+                make_plain_test_program(snippet, color_enabled: color_enabled)
+
+              expected_output =
+                build_expected_output(
+                  color_enabled: color_enabled,
+                  snippet:
+                    "expect { }.to raise_error(/this is a super super super super super super long message/i)",
+                  newline_before_expectation: true,
+                  expectation:
+                    proc do
+                      line do
+                        plain "Expected "
+                        actual "exception-free block"
+                      end
+
+                      line do
+                        plain "to raise "
+                        expected "a kind of Exception with message matching /this is a super super super super super super long message/i"
+                      end
+                    end
+                )
+
+              expect(program).to produce_output_when_run(
+                expected_output
+              ).in_color(color_enabled)
+            end
+          end
+        end
+      end
+    end
+
+    context "when used in the negative" do
+      it "produces the correct failure message" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            expect { raise 'boo' }.not_to raise_error(/boo/i)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect { raise 'boo' }.not_to raise_error(/boo/i)",
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "Expected raised exception "
+                    actual %|#<RuntimeError "boo">|
+                  end
+
+                  line do
+                    plain "             not to match "
+                    expected "a kind of Exception with message matching /boo/i"
+                  end
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+  end
+
+  context "given both an exception class and string message" do
+    context "when used in the positive" do
+      context "when the block raises a different error than what is given" do
+        context "when the expected and/or actual message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -548,7 +702,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                         plain "Expected raised exception "
                         actual %|#<StandardError "a">|
                         plain " to match "
-                        expected %|#<RuntimeError "b">|
+                        expected %|a kind of RuntimeError with message "b"|
                         plain "."
                       end
                     end
@@ -561,7 +715,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the expected and/or actual message is long" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -586,7 +740,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
 
                       line do
                         plain "                 to match "
-                        expected %|#<RuntimeError "this is another long message">|
+                        expected %|a kind of RuntimeError with message "this is another long message"|
                       end
                     end
                 )
@@ -600,7 +754,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
       end
 
       context "when the block raises no error" do
-        context "when the message is short" do
+        context "when the expected message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -616,8 +770,10 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                   expectation:
                     proc do
                       line do
-                        plain "Expected block to raise error "
-                        expected %|#<RuntimeError "b">|
+                        plain "Expected "
+                        actual "exception-free block"
+                        plain " to raise "
+                        expected %|a kind of RuntimeError with message "b"|
                         plain "."
                       end
                     end
@@ -630,7 +786,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the expected message is long" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -648,13 +804,13 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                   expectation:
                     proc do
                       line do
-                        plain "      Expected "
-                        plain "block"
+                        plain "Expected "
+                        actual "exception-free block"
                       end
 
                       line do
-                        plain "to raise error "
-                        expected %|#<RuntimeError "this is a super super super super super super long message">|
+                        plain "to raise "
+                        expected %|a kind of RuntimeError with message "this is a super super super super super super long message"|
                       end
                     end
                 )
@@ -669,83 +825,191 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
 
     context "when used in the negative" do
-      context "when the message is short" do
-        it "produces the correct failure message" do
-          as_both_colored_and_uncolored do |color_enabled|
-            snippet = <<~TEST.strip
-              block = -> { raise StandardError.new('a') }
-              expect(&block).not_to raise_error(StandardError, 'a')
-            TEST
-            program =
-              make_plain_test_program(snippet, color_enabled: color_enabled)
+      it "produces the correct failure message" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            block = -> { raise StandardError.new('a') }
+            expect(&block).not_to raise_error(StandardError, 'a')
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
 
-            expected_output =
-              build_expected_output(
-                color_enabled: color_enabled,
-                snippet:
-                  "expect(&block).not_to raise_error(StandardError, 'a')",
-                expectation:
-                  proc do
-                    line do
-                      plain "Expected raised exception "
-                      actual %|#<StandardError "a">|
-                      plain " not to match "
-                      expected %|#<StandardError "a">|
-                      plain "."
-                    end
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(&block).not_to raise_error(StandardError, 'a')",
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "Expected raised exception "
+                    actual %|#<StandardError "a">|
                   end
-              )
 
-            expect(program).to produce_output_when_run(
-              expected_output
-            ).in_color(color_enabled)
-          end
-        end
-      end
-
-      context "when the message is long" do
-        it "produces the correct failure message" do
-          as_both_colored_and_uncolored do |color_enabled|
-            snippet = <<~TEST.strip
-              block = -> { raise StandardError.new('this is a long message') }
-              expect(&block).not_to raise_error(StandardError, 'this is a long message')
-            TEST
-            program =
-              make_plain_test_program(snippet, color_enabled: color_enabled)
-
-            expected_output =
-              build_expected_output(
-                color_enabled: color_enabled,
-                snippet:
-                  "expect(&block).not_to raise_error(StandardError, 'this is a long message')",
-                newline_before_expectation: true,
-                expectation:
-                  proc do
-                    line do
-                      plain "Expected raised exception "
-                      actual %|#<StandardError "this is a long message">|
-                    end
-
-                    line do
-                      plain "             not to match "
-                      expected %|#<StandardError "this is a long message">|
-                    end
+                  line do
+                    plain "             not to match "
+                    expected %|a kind of StandardError with message "a"|
                   end
-              )
+                end
+            )
 
-            expect(program).to produce_output_when_run(
-              expected_output
-            ).in_color(color_enabled)
-          end
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
         end
       end
     end
   end
 
-  context "with a simple RSpec matcher" do
+  context "given both an exception class and regexp message" do
     context "when used in the positive" do
       context "when the block raises a different error than what is given" do
-        context "when the message is short" do
+        it "produces the correct failure message" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              block = -> { raise StandardError.new('a') }
+              expect(&block).to raise_error(RuntimeError, /b/i)
+            TEST
+            program =
+              make_plain_test_program(snippet, color_enabled: color_enabled)
+
+            expected_output =
+              build_expected_output(
+                color_enabled: color_enabled,
+                snippet: "expect(&block).to raise_error(RuntimeError, /b/i)",
+                newline_before_expectation: true,
+                expectation:
+                  proc do
+                    line do
+                      plain "Expected raised exception "
+                      actual %|#<StandardError "a">|
+                    end
+
+                    line do
+                      plain "                 to match "
+                      expected "a kind of RuntimeError with message matching /b/i"
+                    end
+                  end
+              )
+
+            expect(program).to produce_output_when_run(
+              expected_output
+            ).in_color(color_enabled)
+          end
+        end
+      end
+
+      context "when the block raises no error" do
+        context "when the expected message is short" do
+          it "produces the correct failure message" do
+            as_both_colored_and_uncolored do |color_enabled|
+              snippet = <<~TEST.strip
+                expect { }.to raise_error(RuntimeError, /b/i)
+              TEST
+              program =
+                make_plain_test_program(snippet, color_enabled: color_enabled)
+
+              expected_output =
+                build_expected_output(
+                  color_enabled: color_enabled,
+                  snippet: "expect { }.to raise_error(RuntimeError, /b/i)",
+                  expectation:
+                    proc do
+                      line do
+                        plain "Expected "
+                        actual "exception-free block"
+                        plain " to raise "
+                        expected "a kind of RuntimeError with message matching /b/i"
+                      end
+                    end
+                )
+
+              expect(program).to produce_output_when_run(
+                expected_output
+              ).in_color(color_enabled)
+            end
+          end
+        end
+
+        context "when the expected message is long" do
+          it "produces the correct failure message" do
+            as_both_colored_and_uncolored do |color_enabled|
+              snippet = <<~TEST.strip
+                expect { }.to raise_error(RuntimeError, /this is a super super super super super super long message/i)
+              TEST
+              program =
+                make_plain_test_program(snippet, color_enabled: color_enabled)
+
+              expected_output =
+                build_expected_output(
+                  color_enabled: color_enabled,
+                  snippet:
+                    "expect { }.to raise_error(RuntimeError, /this is a super super super super super super long message/i)",
+                  newline_before_expectation: true,
+                  expectation:
+                    proc do
+                      line do
+                        plain "Expected "
+                        actual "exception-free block"
+                      end
+
+                      line do
+                        plain "to raise "
+                        expected "a kind of RuntimeError with message matching /this is a super super super super super super long message/i"
+                      end
+                    end
+                )
+
+              expect(program).to produce_output_when_run(
+                expected_output
+              ).in_color(color_enabled)
+            end
+          end
+        end
+      end
+    end
+
+    context "when used in the negative" do
+      it "produces the correct failure message" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+              block = -> { raise StandardError.new('a') }
+              expect(&block).not_to raise_error(StandardError, /a/i)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet: "expect(&block).not_to raise_error(StandardError, /a/i)",
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "Expected raised exception "
+                    actual %|#<StandardError "a">|
+                  end
+
+                  line do
+                    plain "             not to match "
+                    expected "a kind of StandardError with message matching /a/i"
+                  end
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+  end
+
+  context "given a simple RSpec fuzzy object" do
+    context "when used in the positive" do
+      context "when the block raises a different error than what is given" do
+        context "when the expected error and/or actual message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -778,7 +1042,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
+        context "when the expected error and/or actual message is long" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
@@ -831,7 +1095,9 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                 expectation:
                   proc do
                     line do
-                      plain "Expected block to raise error "
+                      plain "Expected "
+                      actual "exception-free block"
+                      plain " to raise "
                       expected "#<a kind of RuntimeError>"
                       plain "."
                     end
@@ -847,7 +1113,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
 
     context "when used in the negative" do
-      context "when the message is short" do
+      context "when the expected error and/or actual message is short" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -880,7 +1146,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
         end
       end
 
-      context "when the message is long" do
+      context "when the expected error and/or actual message is long" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -918,14 +1184,168 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
   end
 
-  context "with a compound RSpec matcher" do
+  context "given only a simple RSpec fuzzy object and string message" do
     context "when used in the positive" do
       context "when the block raises a different error than what is given" do
-        context "when the message is short" do
+        it "produces the correct failure message" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+              expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), "boo")
+            TEST
+            program =
+              make_plain_test_program(snippet, color_enabled: color_enabled)
+
+            expected_output =
+              build_expected_output(
+                color_enabled: color_enabled,
+                snippet:
+                  %|expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), "boo")|,
+                newline_before_expectation: true,
+                expectation:
+                  proc do
+                    line do
+                      plain "Expected raised exception "
+                      actual %|#<StandardError "boo">|
+                    end
+
+                    line do
+                      plain "                 to match "
+                      expected %|#<a kind of RuntimeError> with message "boo"|
+                    end
+                  end
+              )
+
+            expect(program).to produce_output_when_run(
+              expected_output
+            ).in_color(color_enabled)
+          end
+        end
+      end
+    end
+
+    context "when used in the negative" do
+      it "produces the correct failure message" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            expect { raise StandardError.new('boo') }.not_to raise_error(a_kind_of(StandardError), "boo")
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet:
+                %|expect { raise StandardError.new('boo') }.not_to raise_error(a_kind_of(StandardError), "boo")|,
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "Expected raised exception "
+                    actual %|#<StandardError "boo">|
+                  end
+
+                  line do
+                    plain "             not to match "
+                    expected %|#<a kind of StandardError> with message "boo"|
+                  end
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+  end
+
+  context "given only a simple RSpec fuzzy object and regexp message" do
+    context "when used in the positive" do
+      context "when the block raises a different error than what is given" do
+        it "produces the correct failure message" do
+          as_both_colored_and_uncolored do |color_enabled|
+            snippet = <<~TEST.strip
+                expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), /boo/i)
+            TEST
+            program =
+              make_plain_test_program(snippet, color_enabled: color_enabled)
+
+            expected_output =
+              build_expected_output(
+                color_enabled: color_enabled,
+                snippet:
+                  "expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), /boo/i)",
+                newline_before_expectation: true,
+                expectation:
+                  proc do
+                    line do
+                      plain "Expected raised exception "
+                      actual %|#<StandardError "boo">|
+                    end
+
+                    line do
+                      plain "                 to match "
+                      expected "#<a kind of RuntimeError> with message matching /boo/i"
+                    end
+                  end
+              )
+
+            expect(program).to produce_output_when_run(
+              expected_output
+            ).in_color(color_enabled)
+          end
+        end
+      end
+    end
+
+    context "when used in the negative" do
+      it "produces the correct failure message" do
+        as_both_colored_and_uncolored do |color_enabled|
+          snippet = <<~TEST.strip
+            expect { raise StandardError.new('boo') }.not_to raise_error(a_kind_of(StandardError), /boo/i)
+          TEST
+          program =
+            make_plain_test_program(snippet, color_enabled: color_enabled)
+
+          expected_output =
+            build_expected_output(
+              color_enabled: color_enabled,
+              snippet:
+                "expect { raise StandardError.new('boo') }.not_to raise_error(a_kind_of(StandardError), /boo/i)",
+              newline_before_expectation: true,
+              expectation:
+                proc do
+                  line do
+                    plain "Expected raised exception "
+                    actual %|#<StandardError "boo">|
+                  end
+
+                  line do
+                    plain "             not to match "
+                    expected "#<a kind of StandardError> with message matching /boo/i"
+                  end
+                end
+            )
+
+          expect(program).to produce_output_when_run(expected_output).in_color(
+            color_enabled
+          )
+        end
+      end
+    end
+  end
+
+  # NOTE: No need to test this using a string or regexp message — we've tested
+  # it enough above
+  context "given a compound RSpec fuzzy object" do
+    context "when used in the positive" do
+      context "when the block raises a different error than what is given" do
+        context "when the expected error and/or actual message is short" do
           it "produces the correct failure message" do
             as_both_colored_and_uncolored do |color_enabled|
               snippet = <<~TEST.strip
-                expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(Array).or eq(true))
+                  expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(Array).or eq(true))
               TEST
               program =
                 make_plain_test_program(snippet, color_enabled: color_enabled)
@@ -954,41 +1374,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
           end
         end
 
-        context "when the message is long" do
-          it "produces the correct failure message" do
-            as_both_colored_and_uncolored do |color_enabled|
-              snippet = <<~TEST.strip
-                expect { raise StandardError.new('this is a super super super long message') }.to raise_error(a_kind_of(RuntimeError).and having_attributes(beep: :boop))
-              TEST
-              program =
-                make_plain_test_program(snippet, color_enabled: color_enabled)
-
-              expected_output =
-                build_expected_output(
-                  color_enabled: color_enabled,
-                  snippet:
-                    "expect { raise StandardError.new('this is a super super super long message') }.to raise_error(a_kind_of(RuntimeError).and having_attributes(beep: :boop))",
-                  newline_before_expectation: true,
-                  expectation:
-                    proc do
-                      line do
-                        plain "Expected raised exception "
-                        actual %|#<StandardError "this is a super super super long message">|
-                      end
-
-                      line do
-                        plain "                 to match "
-                        expected "#<a kind of RuntimeError and having attributes (beep: :boop)>"
-                      end
-                    end
-                )
-
-              expect(program).to produce_output_when_run(
-                expected_output
-              ).in_color(color_enabled)
-            end
-          end
-        end
+        context "when the expected error and/or actual message is long"
       end
 
       context "when the block raises no error" do
@@ -1005,12 +1391,17 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                 color_enabled: color_enabled,
                 snippet:
                   "expect { }.to raise_error(a_kind_of(RuntimeError).and having_attributes(beep: :boop))",
+                newline_before_expectation: true,
                 expectation:
                   proc do
                     line do
-                      plain "Expected block to raise error "
+                      plain "Expected "
+                      actual "exception-free block"
+                    end
+
+                    line do
+                      plain "to raise "
                       expected "#<a kind of RuntimeError and having attributes (beep: :boop)>"
-                      plain "."
                     end
                   end
               )
@@ -1024,7 +1415,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
     end
 
     context "when used in the negative" do
-      context "when the message is short" do
+      context "when the expected and/or actual message is short" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -1057,7 +1448,7 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
         end
       end
 
-      context "when the message is long" do
+      context "when the expected and/or actual message is long" do
         it "produces the correct failure message" do
           as_both_colored_and_uncolored do |color_enabled|
             snippet = <<~TEST.strip
@@ -1082,79 +1473,6 @@ RSpec.describe "Integration with RSpec's #raise_error matcher",
                     line do
                       plain "             not to match "
                       expected "#<a kind of StandardError and having attributes (message: #<a kind of String>)>"
-                    end
-                  end
-              )
-
-            expect(program).to produce_output_when_run(
-              expected_output
-            ).in_color(color_enabled)
-          end
-        end
-      end
-    end
-  end
-
-  context "with an RSpec matcher and expected message" do
-    context "when the block raises a different error than what is given" do
-      context "when the message is short" do
-        it "produces the correct failure message" do
-          as_both_colored_and_uncolored do |color_enabled|
-            snippet = <<~TEST.strip
-              expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), "boo")
-            TEST
-            program =
-              make_plain_test_program(snippet, color_enabled: color_enabled)
-
-            expected_output =
-              build_expected_output(
-                color_enabled: color_enabled,
-                snippet:
-                  "expect { raise StandardError.new('boo') }.to raise_error(a_kind_of(RuntimeError), \"boo\")",
-                expectation:
-                  proc do
-                    line do
-                      plain "Expected raised exception "
-                      actual %|#<StandardError "boo">|
-                      plain " to match "
-                      expected "#<a kind of RuntimeError \"boo\">"
-                      plain "."
-                    end
-                  end
-              )
-
-            expect(program).to produce_output_when_run(
-              expected_output
-            ).in_color(color_enabled)
-          end
-        end
-      end
-
-      context "when the message is long" do
-        it "produces the correct failure message" do
-          as_both_colored_and_uncolored do |color_enabled|
-            snippet = <<~TEST.strip
-              expect { raise StandardError.new('this is a super super super long message') }.to raise_error(a_kind_of(RuntimeError), "beep")
-            TEST
-            program =
-              make_plain_test_program(snippet, color_enabled: color_enabled)
-
-            expected_output =
-              build_expected_output(
-                color_enabled: color_enabled,
-                snippet:
-                  "expect { raise StandardError.new('this is a super super super long message') }.to raise_error(a_kind_of(RuntimeError), \"beep\")",
-                newline_before_expectation: true,
-                expectation:
-                  proc do
-                    line do
-                      plain "Expected raised exception "
-                      actual %|#<StandardError "this is a super super super long message">|
-                    end
-
-                    line do
-                      plain "                 to match "
-                      expected "#<a kind of RuntimeError \"beep\">"
                     end
                   end
               )

--- a/spec/unit/rspec/matchers/raise_error_spec.rb
+++ b/spec/unit/rspec/matchers/raise_error_spec.rb
@@ -5,47 +5,71 @@ RSpec.describe "RSpec's `raise_error` matcher" do
     context "given only an exception class" do
       it "returns the correct output" do
         expect(raise_error(RuntimeError).description).to eq(
-          "raise error #<RuntimeError>"
+          "raise a kind of RuntimeError"
         )
       end
     end
 
-    context "with only a message (and assuming a RuntimeError)" do
+    context "given only a string message" do
       it "returns the correct output" do
         expect(raise_error("hell").description).to eq(
-          %|raise error #<Exception "hell">|
+          %|raise a kind of Exception with message "hell"|
         )
       end
     end
 
-    context "with regular expression as message (and assuming a RuntimeError)" do
+    context "given only a regexp message" do
       it "returns the correct output" do
-        expect(raise_error(/hell/).description).to eq(
-          "raise error #<Exception /hell/>"
+        expect(raise_error(/hell/i).description).to eq(
+          "raise a kind of Exception with message matching /hell/i"
         )
       end
     end
 
-    context "with both an exception and a message" do
+    context "given both an exception and string message" do
       it "returns the correct output" do
         expect(raise_error(RuntimeError, "hell").description).to eq(
-          %|raise error #<RuntimeError "hell">|
+          %|raise a kind of RuntimeError with message "hell"|
         )
       end
     end
 
-    context "with an exception and a regular expression as message" do
+    context "given both an exception and regexp message" do
       it "returns the correct output" do
-        expect(raise_error(RuntimeError, /hell/).description).to eq(
-          "raise error #<RuntimeError /hell/>"
+        expect(raise_error(RuntimeError, /hell/i).description).to eq(
+          "raise a kind of RuntimeError with message matching /hell/i"
         )
       end
     end
 
-    context "with a matcher" do
+    context "given a simple RSpec fuzzy object" do
       it "returns the correct output" do
         expect(raise_error(a_kind_of(RuntimeError)).description).to eq(
-          "raise error #<a kind of RuntimeError>"
+          "raise #<a kind of RuntimeError>"
+        )
+      end
+    end
+
+    context "given a simple RSpec fuzzy object and string message" do
+      it "returns the correct output" do
+        expect(raise_error(a_kind_of(RuntimeError), "boo").description).to eq(
+          'raise #<a kind of RuntimeError> with message "boo"'
+        )
+      end
+    end
+
+    context "given a simple RSpec fuzzy object and regexp message" do
+      it "returns the correct output" do
+        expect(raise_error(a_kind_of(RuntimeError), /boo/i).description).to eq(
+          "raise #<a kind of RuntimeError> with message matching /boo/i"
+        )
+      end
+    end
+
+    context "given a compound RSpec fuzzy object" do
+      it "returns the correct output" do
+        expect(raise_error(a_kind_of(Array).or eq(true)).description).to eq(
+          "raise #<a kind of Array or eq true>"
         )
       end
     end


### PR DESCRIPTION
This commit makes some minor changes to the `raise_error` matcher to make the failure messages slightly more friendly and consistent with the overall philosophy of matchers in this repo.

Here are the current messages in comparison with the new ones:

- In cases where the block raises no error, the wording changes from "Expected block" to "Expected exception-free block", and "exception-free block" is highlighted in the actual color. This is to emphasize the actual behavior vs. the expected behavior and matches other matchers.
- In cases where only an expected error class is provided, the wording changes so that instead of inspecting the expected error, the failure message says "a kind of" followed by the class name.
- In cases where a message is provided, the expected class and message are separated in the failure message.
- In cases where a regexp message is provided, the wording changes from "with message #{message}" to "with message matching #{message}".

Additionally, the integration tests for `raise_error` have been reviewed and missing tests have been filled in.