### PR TITLE
Fix GitHub workflow

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -246,7 +246,7 @@ jobs:
         run: |
           set -x
           DOCSITE_DESTINATION_PARENT_PATH="$(dirname "$DOCSITE_DESTINATION_PATH")"
-          echo "DOCSITE_DESTINATION_PARENT_PATH=$DOCSITE_DESTINATION_PARENT_PATH" >> "GITHUB_ENV"
+          echo "DOCSITE_DESTINATION_PARENT_PATH=$DOCSITE_DESTINATION_PARENT_PATH" >> "$GITHUB_ENV"
         env:
           DOCSITE_DESTINATION_PATH: ${{ needs.collect-docsite-release-info.outputs.DOCSITE_DESTINATION_PATH }}
       - name: Remove ${{ env.DOCSITE_DESTINATION_PARENT_PATH }} on gh-pages


### PR DESCRIPTION
This ends up creating a rogue `GITHUB_ENV` file on the `gh-pages` branch instead of setting an environment variable.