### PR TITLE
Add lint:changed and lint:changed:fix

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,22 +9,7 @@ if echo "$stdin" | grep -q "^(delete)"; then
   exit 0
 fi
 
-current_branch_name="$(git branch --show-current)"
-
-if [[ "$current_branch_name" == "main" ]]; then
-  raw_files_to_check="$(git diff origin/main...HEAD --name-only --diff-filter=d)"
-else
-  raw_files_to_check="$(git diff main...HEAD --name-only --diff-filter=d)"
-fi
-
-if [[ -n "$raw_files_to_check" ]]; then
-  echo "*** Checking for lint violations in changed files ***************"
-  echo
-
-  echo "$raw_files_to_check" | while IFS=$'\n' read -r line; do
-    printf '%s\0' "$line"
-  done | xargs -0 yarn prettier --check --ignore-unknown || exit $?
-fi
+scripts/lint-changed-files.sh --check
 
 echo
 echo "*** Auditing dependencies ***************"

--- a/docs/contributors/how-to-contribute.md
+++ b/docs/contributors/how-to-contribute.md
@@ -93,6 +93,12 @@ yarn lint:fix
 Provided that you ran `bin/setup` above,
 any code you've changed will also be linted
 whenever you push a commit.
+If this step fails for any reason,
+you can fix lint violations in only changed files by running:
+
+```
+yarn lint:changed:fix
+```
 
 [prettier-editors]: https://prettier.io/docs/en/editors.html
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "private": true,
   "scripts": {
     "audit": "yarn npm audit && bundle exec bundle audit --gemfile-lock ${BUNDLE_GEMFILE:-Gemfile}",
-    "lint": "prettier --check .",
-    "lint:fix": "yarn lint --write",
+    "lint": "scripts/lint-all-files.sh --check",
+    "lint:fix": "scripts/lint-all-files.sh --write",
+    "lint:changed": "scripts/lint-changed-files.sh --include-uncommitted --check",
+    "lint:changed:fix": "scripts/lint-changed-files.sh --include-uncommitted --write",
     "setup-git-hooks": "husky install"
   },
   "devDependencies": {

--- a/scripts/lint-all-files.sh
+++ b/scripts/lint-all-files.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec prettier "$@" .

--- a/scripts/lint-changed-files.sh
+++ b/scripts/lint-changed-files.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+get-files-to-lint() {
+  local flag="$1"
+  local current_branch_name="$(git branch --show-current)"
+
+  if [[ "$current_branch_name" == "main" ]]; then
+    git diff origin/main...HEAD --name-only --diff-filter=d
+  else
+    git diff main...HEAD --name-only --diff-filter=d
+  fi
+
+  if [[ $flag == "--include-uncommitted" ]]; then
+    git diff --name-only --diff-filter=d
+  fi
+}
+
+main() {
+  local prettier_flag
+  local include_uncommitted_flag
+
+  while [[ -n "$1" ]]; do
+    case "$1" in
+      --check | --write)
+        prettier_flag="$1"
+        shift
+        ;;
+      --include-uncommitted)
+        include_uncommitted_flag="$1"
+        shift
+        ;;
+      *)
+        echo "ERROR: Unknown option $1."
+        exit 1
+        ;;
+    esac
+  done
+
+  local files_to_lint="$(get-files-to-lint "$include_uncommitted_flag")"
+
+  if [[ -z "$prettier_flag" ]]; then
+    echo "ERROR: Missing --check or --write."
+    exit 1
+  fi
+
+  echo "*** Checking for lint violations in changed files ***************"
+  echo
+
+  if [[ -n "$files_to_lint" ]]; then
+    echo "Files to check:"
+    echo "$files_to_lint" | while IFS=$'\n' read -r line; do
+      echo "- $line"
+    done
+
+    echo
+    echo "$files_to_lint" | while IFS=$'\n' read -r line; do
+      printf '%s\0' "$line"
+    done | xargs -0 yarn prettier "$prettier_flag" --ignore-unknown
+  else
+    echo "No files to lint this time."
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
The Git hook that runs on push will only lint files changed within the current branch. However, it won't fix anything; to do that, you'll have to run `yarn lint:fix`. But actually, this runs every file through the linter, so it's fairly inefficient. This commit adds `lint:changed` and `lint:changed:fix` so that you can do the same thing that the Git hook does.