### PR TITLE
Add Rails 7.1 appraisal.

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -57,6 +57,7 @@ jobs:
         rails_appraisal:
           - rails_6_1
           - rails_7_0
+          - rails_7_1
           - no_rails
         rspec_appraisal:
           - rspec_lt_3_10


### PR DESCRIPTION
This unblocks adding specs to test Rails 7.1 compatibility.