### PR TITLE
Remove use of `pp` in DifferDispatcher

### DIFF
--- a/lib/super_diff/core/differ_dispatcher.rb
+++ b/lib/super_diff/core/differ_dispatcher.rb
@@ -10,8 +10,6 @@ module SuperDiff
       )
 
       def call
-        pp available_classes: available_classes
-
         if resolved_class
           resolved_class.call(expected, actual, indent_level: indent_level)
         elsif raise_if_nothing_applies?


### PR DESCRIPTION
Was causing the following output when running tests in Rails app using super_diff:

```
{:available_classes=>
  [SuperDiff::ActiveRecord::Differs::ActiveRecordRelation,
   SuperDiff::ActiveSupport::Differs::HashWithIndifferentAccess,
   SuperDiff::RSpec::Differs::CollectionContainingExactly,
   SuperDiff::RSpec::Differs::CollectionIncluding,
   SuperDiff::RSpec::Differs::HashIncluding,
   SuperDiff::RSpec::Differs::ObjectHavingAttributes,
   SuperDiff::Basic::Differs::Array,
   SuperDiff::Basic::Differs::Hash,
   SuperDiff::Basic::Differs::TimeLike,
   SuperDiff::Basic::Differs::DateLike,
   SuperDiff::Basic::Differs::MultilineString,
   SuperDiff::Basic::Differs::CustomObject,
   SuperDiff::Basic::Differs::DefaultObject]}
```

![available_classes_output](https://github.com/mcmire/super_diff/assets/53722/78e5c98c-a5a7-43aa-8248-aff6263c2105)