### PR TITLE
Fix GH workflow so docs deploy on new releases

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -120,25 +120,25 @@ jobs:
         run: |
           set -x
 
-          if [[ "$IS_NEW_RELEASE" == "true" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF_NAME" == "main" && "$IS_NEW_RELEASE" == "true" ]]; then
             DOCSITE_RELEASE_VERSION="$RELEASE_VERSION"
             DOCSITE_DESTINATION_PATH="releases/$RELEASE_VERSION"
-            HAS_CHANGES_TO_DOCS="true"
+            HAS_DOCS_CHANGES_TO_RELEASE="true"
           else
             DOCSITE_RELEASE_VERSION="$COMMIT_ID"
             DOCSITE_DESTINATION_PATH="branches/$BRANCH_NAME/$COMMIT_ID"
             # Check if there any changes to docs/
             if git diff --quiet --merge-base "origin/$GITHUB_BASE_REF" -- docs; then
-              HAS_CHANGES_TO_DOCS="false"
+              HAS_DOCS_CHANGES_TO_RELEASE="false"
             else
-              HAS_CHANGES_TO_DOCS="true"
+              HAS_DOCS_CHANGES_TO_RELEASE="true"
             fi
           fi
 
           {
             echo "DOCSITE_RELEASE_VERSION=$DOCSITE_RELEASE_VERSION"
             echo "DOCSITE_DESTINATION_PATH=$DOCSITE_DESTINATION_PATH"
-            echo "HAS_CHANGES_TO_DOCS=$HAS_CHANGES_TO_DOCS"
+            echo "HAS_DOCS_CHANGES_TO_RELEASE=$HAS_DOCS_CHANGES_TO_RELEASE"
           } >> "$GITHUB_OUTPUT"
         env:
           IS_NEW_RELEASE: ${{ needs.collect-release-info.outputs.IS_NEW_RELEASE }}
@@ -148,7 +148,7 @@ jobs:
     outputs:
       DOCSITE_RELEASE_VERSION: ${{ steps.command.outputs.DOCSITE_RELEASE_VERSION }}
       DOCSITE_DESTINATION_PATH: ${{ steps.command.outputs.DOCSITE_DESTINATION_PATH }}
-      HAS_CHANGES_TO_DOCS: ${{ steps.command.outputs.HAS_CHANGES_TO_DOCS }}
+      HAS_DOCS_CHANGES_TO_RELEASE: ${{ steps.command.outputs.HAS_DOCS_CHANGES_TO_RELEASE }}
 
   build-docsite:
     runs-on: ubuntu-latest
@@ -156,7 +156,7 @@ jobs:
       - analyze
       - collect-release-info
       - collect-docsite-release-info
-    if: ${{ github.event_name == 'pull_request' && ((needs.collect-release-info.outputs.IS_NEW_RELEASE == 'false' && needs.collect-docsite-release-info.outputs.HAS_CHANGES_TO_DOCS == 'true') || (needs.collect-release-info.outputs.IS_NEW_RELEASE == 'true' && github.event.merged)) }}
+    if: ${{ needs.collect-docsite-release-info.outputs.HAS_DOCS_CHANGES_TO_RELEASE == 'true' }}
     steps:
       - uses: actions/checkout@v4
       - name: Install poetry
@@ -178,6 +178,8 @@ jobs:
     needs:
       - collect-release-info
       - collect-docsite-release-info
+      # This already runs if there are docs changes to publish, so we don't need
+      # to check that here
       - build-docsite
     steps:
       - uses: actions/checkout@v4
@@ -191,18 +193,19 @@ jobs:
       - name: Update redirect in index (for a release)
         if: ${{ needs.collect-release-info.outputs.IS_NEW_RELEASE == 'true' }}
         run: |
+          url="https://${GITHUB_REPOSITORY_OWNER}.github.io/${GITHUB_REPOSITORY#"${GITHUB_REPOSITORY_OWNER}/"}/releases/${DOCSITE_RELEASE_VERSION}"
           cat <<-EOT > index.html
             <!DOCTYPE html>
             <html>
             <head>
               <title>SuperDiff Documentation</title>
-              <meta http-equiv="refresh" content="0; url='https://mcmire.github.com/super_diff/releases/${RELEASE_VERSION}'" />
+              <meta http-equiv="refresh" content="0; url='${url}'" />
             </head>
             <body>
               <p>
                 This page has moved to a different URL.
                 Please click
-                <a href="https://mcmire.github.com/super_diff/releases/${RELEASE_VERSION}">
+                <a href="${url}">
                   this link
                 </a>
                 if you are not redirected.
@@ -210,6 +213,8 @@ jobs:
             </body>
             </html>
           EOT
+        env:
+          DOCSITE_RELEASE_VERSION: ${{ needs.collect-docsite-release-info.outputs.DOCSITE_RELEASE_VERSION }}
       - name: Copy site/ to ${{ needs.collect-docsite-release-info.outputs.DOCSITE_DESTINATION_PATH }}
         run: |
           mkdir -p "$(dirname "$DOCSITE_DESTINATION_PATH")"
@@ -226,6 +231,7 @@ jobs:
         env:
           DOCSITE_DESTINATION_PATH: ${{ needs.collect-docsite-release-info.outputs.DOCSITE_DESTINATION_PATH }}
       - name: Announce publishing of docsite as a comment on the PR
+        if: ${{ github.event_name == 'pull_request' }}
         run: |
           gh pr comment "$PULL_REQUEST_NUMBER" --body ":book: A new version of the docsite has been published at: <https://mcmire.github.io/super_diff/$DOCSITE_DESTINATION_PATH>"
         env:


### PR DESCRIPTION
Previously, when merging a new release, a new version of the docsite would not get deployed. Apparently I misunderstood the purpose of the `github.event.merged` property. I've changed this so that the step to determine the destination for the docsite (and hence whether the docsite should be deployed) looks for the `main` branch to be pushed and for `version.rb` to be updated.

I've also fixed the index page for the docsite so it redirects to the correct release page.