### PR TITLE
Add handling for Data classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+- Add better support for Data object diffing. [#259](https://github.com/splitwise/super_diff/pull/224)
+
 ## 0.12.1 - 2024-04-26
 
 Note that since 0.12.0 has been yanked, changes for this version are listed

--- a/lib/super_diff/basic.rb
+++ b/lib/super_diff/basic.rb
@@ -26,6 +26,7 @@ module SuperDiff
         InspectionTreeBuilders::Primitive,
         InspectionTreeBuilders::TimeLike,
         InspectionTreeBuilders::DateLike,
+        InspectionTreeBuilders::DataObject,
         InspectionTreeBuilders::DefaultObject
       )
 

--- a/lib/super_diff/basic.rb
+++ b/lib/super_diff/basic.rb
@@ -34,7 +34,8 @@ module SuperDiff
         OperationTreeBuilders::Hash,
         OperationTreeBuilders::TimeLike,
         OperationTreeBuilders::DateLike,
-        OperationTreeBuilders::CustomObject
+        OperationTreeBuilders::CustomObject,
+        OperationTreeBuilders::DataObject
       )
 
       config.add_extra_operation_tree_classes(

--- a/lib/super_diff/basic/inspection_tree_builders.rb
+++ b/lib/super_diff/basic/inspection_tree_builders.rb
@@ -7,6 +7,10 @@ module SuperDiff
         "super_diff/basic/inspection_tree_builders/custom_object"
       )
       autoload(
+        :DataObject,
+        "super_diff/basic/inspection_tree_builders/data_object"
+      )
+      autoload(
         :DefaultObject,
         "super_diff/basic/inspection_tree_builders/default_object"
       )

--- a/lib/super_diff/basic/inspection_tree_builders/data_object.rb
+++ b/lib/super_diff/basic/inspection_tree_builders/data_object.rb
@@ -1,0 +1,40 @@
+module SuperDiff
+  module Basic
+    module InspectionTreeBuilders
+      class DataObject < Core::AbstractInspectionTreeBuilder
+        def self.applies_to?(value)
+          SuperDiff::Core::Helpers.ruby_version_matches?("~> 3.2") &&
+            value.is_a?(Data)
+        end
+
+        def call
+          Core::InspectionTree.new do |t1|
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :open
+            ) do |t2|
+              t2.add_text "#<data #{object.class.name} "
+
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "{"
+              end
+            end
+
+            t1.nested { |t2| t2.insert_hash_inspection_of(object.to_h) }
+
+            t1.as_lines_when_rendering_to_lines(
+              collection_bookend: :close
+            ) do |t2|
+              # stree-ignore
+              t2.when_rendering_to_lines do |t3|
+                t3.add_text "}"
+              end
+
+              t2.add_text ">"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/basic/operation_tree_builders.rb
+++ b/lib/super_diff/basic/operation_tree_builders.rb
@@ -2,6 +2,7 @@ module SuperDiff
   module Basic
     module OperationTreeBuilders
       autoload :Array, "super_diff/basic/operation_tree_builders/array"
+      autoload :DataObject, "super_diff/basic/operation_tree_builders/data_object"
       autoload(
         :CustomObject,
         "super_diff/basic/operation_tree_builders/custom_object"

--- a/lib/super_diff/basic/operation_tree_builders.rb
+++ b/lib/super_diff/basic/operation_tree_builders.rb
@@ -2,10 +2,13 @@ module SuperDiff
   module Basic
     module OperationTreeBuilders
       autoload :Array, "super_diff/basic/operation_tree_builders/array"
-      autoload :DataObject, "super_diff/basic/operation_tree_builders/data_object"
       autoload(
         :CustomObject,
         "super_diff/basic/operation_tree_builders/custom_object"
+      )
+      autoload(
+        :DataObject,
+        "super_diff/basic/operation_tree_builders/data_object"
       )
       autoload(
         :DefaultObject,

--- a/lib/super_diff/basic/operation_tree_builders/data_object.rb
+++ b/lib/super_diff/basic/operation_tree_builders/data_object.rb
@@ -3,10 +3,12 @@ module SuperDiff
     module OperationTreeBuilders
       class DataObject < CustomObject
         def self.applies_to?(expected, actual)
-          return false unless SuperDiff::Core::Helpers.ruby_version_matches?('~> 3.2')
+          unless SuperDiff::Core::Helpers.ruby_version_matches?("~> 3.2")
+            return false
+          end
 
-          expected.class == actual.class &&
-            expected.is_a?(Data) && actual.is_a?(Data)
+          expected.class == actual.class && expected.is_a?(Data) &&
+            actual.is_a?(Data)
         end
 
         protected

--- a/lib/super_diff/basic/operation_tree_builders/data_object.rb
+++ b/lib/super_diff/basic/operation_tree_builders/data_object.rb
@@ -3,12 +3,8 @@ module SuperDiff
     module OperationTreeBuilders
       class DataObject < CustomObject
         def self.applies_to?(expected, actual)
-          unless SuperDiff::Core::Helpers.ruby_version_matches?("~> 3.2")
-            return false
-          end
-
-          expected.class == actual.class && expected.is_a?(Data) &&
-            actual.is_a?(Data)
+          SuperDiff::Core::Helpers.ruby_version_matches?("~> 3.2") &&
+            expected.class == actual.class && expected.is_a?(Data)
         end
 
         protected

--- a/lib/super_diff/basic/operation_tree_builders/data_object.rb
+++ b/lib/super_diff/basic/operation_tree_builders/data_object.rb
@@ -1,0 +1,20 @@
+module SuperDiff
+  module Basic
+    module OperationTreeBuilders
+      class DataObject < CustomObject
+        def self.applies_to?(expected, actual)
+          return false unless SuperDiff::Core::Helpers.ruby_version_matches?('~> 3.2')
+
+          expected.class == actual.class &&
+            expected.is_a?(Data) && actual.is_a?(Data)
+        end
+
+        protected
+
+        def attribute_names
+          expected.members & actual.members
+        end
+      end
+    end
+  end
+end

--- a/spec/support/models/point.rb
+++ b/spec/support/models/point.rb
@@ -1,0 +1,5 @@
+module SuperDiff
+  module Test
+    Point = Data.define(:x, :y)
+  end
+end

--- a/spec/support/models/point.rb
+++ b/spec/support/models/point.rb
@@ -1,5 +1,7 @@
-module SuperDiff
-  module Test
-    Point = Data.define(:x, :y)
+if defined?(Data)
+  module SuperDiff
+    module Test
+      Point = Data.define(:x, :y)
+    end
   end
 end

--- a/spec/unit/basic/inspection_tree_builders/data_object_spec.rb
+++ b/spec/unit/basic/inspection_tree_builders/data_object_spec.rb
@@ -1,142 +1,144 @@
 require "spec_helper"
 
-RSpec.describe SuperDiff, type: :unit do
-  describe ".inspect_object" do
-    context "given as_lines: false" do
-      subject(:output) do
-        described_class.inspect_object(object, as_lines: false)
-      end
-
-      context "given an anonymous Data object" do
-        let(:object) { Data.define(:x, :y).new(1, 2) }
-
-        it "shows the data" do
-          expect(output).to eq("#<data  x: 1, y: 2>")
+if defined?(Data)
+  RSpec.describe SuperDiff, type: :unit do
+    describe ".inspect_object" do
+      context "given as_lines: false" do
+        subject(:output) do
+          described_class.inspect_object(object, as_lines: false)
         end
-      end
 
-      context "given a named Data object" do
-        let(:object) { SuperDiff::Test::Point.new(1, 2) }
+        context "given an anonymous Data object" do
+          let(:object) { Data.define(:x, :y).new(1, 2) }
 
-        it "shows the data" do
-          expect(output).to eq("#<data SuperDiff::Test::Point x: 1, y: 2>")
-        end
-      end
-
-      context "given a Data object that defines #attributes_for_super_diff" do
-        let(:klass) do
-          Data.define(:x, :y) do
-            def attributes_for_super_diff
-              { beep: :boop }
-            end
+          it "shows the data" do
+            expect(output).to eq("#<data  x: 1, y: 2>")
           end
         end
-        let(:object) { klass.new(1, 2) }
 
-        it "uses the custom attributes" do
-          expect(output).to start_with("#<#<Class:0x").and end_with(
-                  "beep: :boop>"
+        context "given a named Data object" do
+          let(:object) { SuperDiff::Test::Point.new(1, 2) }
+
+          it "shows the data" do
+            expect(output).to eq("#<data SuperDiff::Test::Point x: 1, y: 2>")
+          end
+        end
+
+        context "given a Data object that defines #attributes_for_super_diff" do
+          let(:klass) do
+            Data.define(:x, :y) do
+              def attributes_for_super_diff
+                { beep: :boop }
+              end
+            end
+          end
+          let(:object) { klass.new(1, 2) }
+
+          it "uses the custom attributes" do
+            expect(output).to start_with("#<#<Class:0x").and end_with(
+                    "beep: :boop>"
+                  )
+          end
+        end
+      end
+
+      context "given as_lines: true" do
+        subject(:tiered_lines) do
+          described_class.inspect_object(
+            object,
+            as_lines: true,
+            type: :noop,
+            indentation_level: 1
+          )
+        end
+
+        context "given an anonymous Data object" do
+          let(:object) { Data.define(:x, :y).new(1, 2) }
+
+          it "shows the data" do
+            expect(tiered_lines).to match(
+              [
+                an_object_having_attributes(
+                  value: "#<data  {",
+                  collection_bookend: :open
+                ),
+                an_object_having_attributes(
+                  prefix: "x: ",
+                  value: "1",
+                  add_comma: true
+                ),
+                an_object_having_attributes(
+                  prefix: "y: ",
+                  value: "2",
+                  add_comma: false
+                ),
+                an_object_having_attributes(
+                  value: "}>",
+                  collection_bookend: :close
                 )
-        end
-      end
-    end
-
-    context "given as_lines: true" do
-      subject(:tiered_lines) do
-        described_class.inspect_object(
-          object,
-          as_lines: true,
-          type: :noop,
-          indentation_level: 1
-        )
-      end
-
-      context "given an anonymous Data object" do
-        let(:object) { Data.define(:x, :y).new(1, 2) }
-
-        it "shows the data" do
-          expect(tiered_lines).to match(
-            [
-              an_object_having_attributes(
-                value: "#<data  {",
-                collection_bookend: :open
-              ),
-              an_object_having_attributes(
-                prefix: "x: ",
-                value: "1",
-                add_comma: true
-              ),
-              an_object_having_attributes(
-                prefix: "y: ",
-                value: "2",
-                add_comma: false
-              ),
-              an_object_having_attributes(
-                value: "}>",
-                collection_bookend: :close
-              )
-            ]
-          )
-        end
-      end
-
-      context "given a named Data object" do
-        let(:object) { SuperDiff::Test::Point.new(1, 2) }
-
-        it "shows the data" do
-          expect(tiered_lines).to match(
-            [
-              an_object_having_attributes(
-                value: "#<data SuperDiff::Test::Point {",
-                collection_bookend: :open
-              ),
-              an_object_having_attributes(
-                prefix: "x: ",
-                value: "1",
-                add_comma: true
-              ),
-              an_object_having_attributes(
-                prefix: "y: ",
-                value: "2",
-                add_comma: false
-              ),
-              an_object_having_attributes(
-                value: "}>",
-                collection_bookend: :close
-              )
-            ]
-          )
-        end
-      end
-
-      context "given a Data object that defines #attributes_for_super_diff" do
-        let(:klass) do
-          Data.define(:x, :y) do
-            def attributes_for_super_diff
-              { beep: :boop }
-            end
+              ]
+            )
           end
         end
-        let(:object) { klass.new(1, 2) }
 
-        it "uses the custom attributes" do
-          expect(tiered_lines).to match(
-            [
-              an_object_having_attributes(
-                value: /\A#<#<Class:0x.*> {/,
-                collection_bookend: :open
-              ),
-              an_object_having_attributes(
-                prefix: "beep: ",
-                value: ":boop",
-                add_comma: false
-              ),
-              an_object_having_attributes(
-                value: "}>",
-                collection_bookend: :close
-              )
-            ]
-          )
+        context "given a named Data object" do
+          let(:object) { SuperDiff::Test::Point.new(1, 2) }
+
+          it "shows the data" do
+            expect(tiered_lines).to match(
+              [
+                an_object_having_attributes(
+                  value: "#<data SuperDiff::Test::Point {",
+                  collection_bookend: :open
+                ),
+                an_object_having_attributes(
+                  prefix: "x: ",
+                  value: "1",
+                  add_comma: true
+                ),
+                an_object_having_attributes(
+                  prefix: "y: ",
+                  value: "2",
+                  add_comma: false
+                ),
+                an_object_having_attributes(
+                  value: "}>",
+                  collection_bookend: :close
+                )
+              ]
+            )
+          end
+        end
+
+        context "given a Data object that defines #attributes_for_super_diff" do
+          let(:klass) do
+            Data.define(:x, :y) do
+              def attributes_for_super_diff
+                { beep: :boop }
+              end
+            end
+          end
+          let(:object) { klass.new(1, 2) }
+
+          it "uses the custom attributes" do
+            expect(tiered_lines).to match(
+              [
+                an_object_having_attributes(
+                  value: /\A#<#<Class:0x.*> {/,
+                  collection_bookend: :open
+                ),
+                an_object_having_attributes(
+                  prefix: "beep: ",
+                  value: ":boop",
+                  add_comma: false
+                ),
+                an_object_having_attributes(
+                  value: "}>",
+                  collection_bookend: :close
+                )
+              ]
+            )
+          end
         end
       end
     end

--- a/spec/unit/basic/inspection_tree_builders/data_object_spec.rb
+++ b/spec/unit/basic/inspection_tree_builders/data_object_spec.rb
@@ -1,0 +1,144 @@
+require "spec_helper"
+
+RSpec.describe SuperDiff, type: :unit do
+  describe ".inspect_object" do
+    context "given as_lines: false" do
+      subject(:output) do
+        described_class.inspect_object(object, as_lines: false)
+      end
+
+      context "given an anonymous Data object" do
+        let(:object) { Data.define(:x, :y).new(1, 2) }
+
+        it "shows the data" do
+          expect(output).to eq("#<data  x: 1, y: 2>")
+        end
+      end
+
+      context "given a named Data object" do
+        let(:object) { SuperDiff::Test::Point.new(1, 2) }
+
+        it "shows the data" do
+          expect(output).to eq("#<data SuperDiff::Test::Point x: 1, y: 2>")
+        end
+      end
+
+      context "given a Data object that defines #attributes_for_super_diff" do
+        let(:klass) do
+          Data.define(:x, :y) do
+            def attributes_for_super_diff
+              { beep: :boop }
+            end
+          end
+        end
+        let(:object) { klass.new(1, 2) }
+
+        it "uses the custom attributes" do
+          expect(output).to start_with("#<#<Class:0x").and end_with(
+                  "beep: :boop>"
+                )
+        end
+      end
+    end
+
+    context "given as_lines: true" do
+      subject(:tiered_lines) do
+        described_class.inspect_object(
+          object,
+          as_lines: true,
+          type: :noop,
+          indentation_level: 1
+        )
+      end
+
+      context "given an anonymous Data object" do
+        let(:object) { Data.define(:x, :y).new(1, 2) }
+
+        it "shows the data" do
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                value: "#<data  {",
+                collection_bookend: :open
+              ),
+              an_object_having_attributes(
+                prefix: "x: ",
+                value: "1",
+                add_comma: true
+              ),
+              an_object_having_attributes(
+                prefix: "y: ",
+                value: "2",
+                add_comma: false
+              ),
+              an_object_having_attributes(
+                value: "}>",
+                collection_bookend: :close
+              )
+            ]
+          )
+        end
+      end
+
+      context "given a named Data object" do
+        let(:object) { SuperDiff::Test::Point.new(1, 2) }
+
+        it "shows the data" do
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                value: "#<data SuperDiff::Test::Point {",
+                collection_bookend: :open
+              ),
+              an_object_having_attributes(
+                prefix: "x: ",
+                value: "1",
+                add_comma: true
+              ),
+              an_object_having_attributes(
+                prefix: "y: ",
+                value: "2",
+                add_comma: false
+              ),
+              an_object_having_attributes(
+                value: "}>",
+                collection_bookend: :close
+              )
+            ]
+          )
+        end
+      end
+
+      context "given a Data object that defines #attributes_for_super_diff" do
+        let(:klass) do
+          Data.define(:x, :y) do
+            def attributes_for_super_diff
+              { beep: :boop }
+            end
+          end
+        end
+        let(:object) { klass.new(1, 2) }
+
+        it "uses the custom attributes" do
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                value: /\A#<#<Class:0x.*> {/,
+                collection_bookend: :open
+              ),
+              an_object_having_attributes(
+                prefix: "beep: ",
+                value: ":boop",
+                add_comma: false
+              ),
+              an_object_having_attributes(
+                value: "}>",
+                collection_bookend: :close
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/basic/operation_tree_builders/data_object_spec.rb
+++ b/spec/unit/basic/operation_tree_builders/data_object_spec.rb
@@ -1,50 +1,22 @@
 require "spec_helper"
 
-RSpec.describe SuperDiff, type: :unit do
-  describe ".diff" do
-    subject(:diff) { described_class.diff(a, b) }
+if defined?(Data)
+  RSpec.describe SuperDiff, type: :unit do
+    describe ".diff" do
+      subject(:diff) { described_class.diff(a, b) }
 
-    context "when given two Data objects of the same class" do
-      let(:a) { SuperDiff::Test::Point.new(1, 2) }
-      let(:b) { SuperDiff::Test::Point.new(1, 3) }
-
-      it "diffs their member attributes" do
-        expected_output =
-          SuperDiff::Core::Helpers
-            .style(color_enabled: true) do
-              plain_line "  #<SuperDiff::Test::Point {"
-              plain_line "    x: 1,"
-              expected_line "-   y: 2"
-              actual_line "+   y: 3"
-              plain_line "  }>"
-            end
-            .to_s
-            .chomp
-
-        expect(diff).to eq(expected_output)
-      end
-
-      context "when the Data class defines #attributes_for_super_diff" do
-        let(:klass) do
-          Class.new(Data.define(:attribute)) do
-            def self.to_s = "TestClass"
-
-            def attributes_for_super_diff
-              { attribute: :does_not_matter }
-            end
-          end
-        end
-
-        let(:a) { klass.new(1) }
-        let(:b) { klass.new(2) }
+      context "when given two Data objects of the same class" do
+        let(:a) { SuperDiff::Test::Point.new(1, 2) }
+        let(:b) { SuperDiff::Test::Point.new(1, 3) }
 
         it "diffs their member attributes" do
           expected_output =
             SuperDiff::Core::Helpers
               .style(color_enabled: true) do
-                plain_line "  #<TestClass {"
-                expected_line "-   attribute: 1"
-                actual_line "+   attribute: 2"
+                plain_line "  #<SuperDiff::Test::Point {"
+                plain_line "    x: 1,"
+                expected_line "-   y: 2"
+                actual_line "+   y: 3"
                 plain_line "  }>"
               end
               .to_s
@@ -52,28 +24,58 @@ RSpec.describe SuperDiff, type: :unit do
 
           expect(diff).to eq(expected_output)
         end
+
+        context "when the Data class defines #attributes_for_super_diff" do
+          let(:klass) do
+            Class.new(Data.define(:attribute)) do
+              def self.to_s = "TestClass"
+
+              def attributes_for_super_diff
+                { attribute: :does_not_matter }
+              end
+            end
+          end
+
+          let(:a) { klass.new(1) }
+          let(:b) { klass.new(2) }
+
+          it "diffs their member attributes" do
+            expected_output =
+              SuperDiff::Core::Helpers
+                .style(color_enabled: true) do
+                  plain_line "  #<TestClass {"
+                  expected_line "-   attribute: 1"
+                  actual_line "+   attribute: 2"
+                  plain_line "  }>"
+                end
+                .to_s
+                .chomp
+
+            expect(diff).to eq(expected_output)
+          end
+        end
       end
-    end
 
-    context "when given two Data objects of different classes" do
-      let(:a) { SuperDiff::Test::Point.new(1, 2) }
-      let(:b) { Data.define(:one, :two).new(1, 2) }
+      context "when given two Data objects of different classes" do
+        let(:a) { SuperDiff::Test::Point.new(1, 2) }
+        let(:b) { Data.define(:one, :two).new(1, 2) }
 
-      it "raises" do
-        expect { SuperDiff.diff(a, b) }.to raise_error(
-          SuperDiff::Core::NoDifferAvailableError
-        )
+        it "raises" do
+          expect { SuperDiff.diff(a, b) }.to raise_error(
+            SuperDiff::Core::NoDifferAvailableError
+          )
+        end
       end
-    end
 
-    context "when given a Data object and a hash" do
-      let(:a) { Data.define(:one, :two).new(1, 2) }
-      let(:b) { { one: 1, two: 2 } }
+      context "when given a Data object and a hash" do
+        let(:a) { Data.define(:one, :two).new(1, 2) }
+        let(:b) { { one: 1, two: 2 } }
 
-      it "raises" do
-        expect { SuperDiff.diff(a, b) }.to raise_error(
-          SuperDiff::Core::NoDifferAvailableError
-        )
+        it "raises" do
+          expect { SuperDiff.diff(a, b) }.to raise_error(
+            SuperDiff::Core::NoDifferAvailableError
+          )
+        end
       end
     end
   end

--- a/spec/unit/basic/operation_tree_builders/data_object_spec.rb
+++ b/spec/unit/basic/operation_tree_builders/data_object_spec.rb
@@ -1,0 +1,80 @@
+require "spec_helper"
+
+RSpec.describe SuperDiff, type: :unit do
+  describe ".diff" do
+    subject(:diff) { described_class.diff(a, b) }
+
+    context "when given two Data objects of the same class" do
+      let(:a) { SuperDiff::Test::Point.new(1, 2) }
+      let(:b) { SuperDiff::Test::Point.new(1, 3) }
+
+      it "diffs their member attributes" do
+        expected_output =
+          SuperDiff::Core::Helpers
+            .style(color_enabled: true) do
+              plain_line "  #<SuperDiff::Test::Point {"
+              plain_line "    x: 1,"
+              expected_line "-   y: 2"
+              actual_line "+   y: 3"
+              plain_line "  }>"
+            end
+            .to_s
+            .chomp
+
+        expect(diff).to eq(expected_output)
+      end
+
+      context "when the Data class defines #attributes_for_super_diff" do
+        let(:klass) do
+          Class.new(Data.define(:attribute)) do
+            def self.to_s = "TestClass"
+
+            def attributes_for_super_diff
+              { attribute: :does_not_matter }
+            end
+          end
+        end
+
+        let(:a) { klass.new(1) }
+        let(:b) { klass.new(2) }
+
+        it "diffs their member attributes" do
+          expected_output =
+            SuperDiff::Core::Helpers
+              .style(color_enabled: true) do
+                plain_line "  #<TestClass {"
+                expected_line "-   attribute: 1"
+                actual_line "+   attribute: 2"
+                plain_line "  }>"
+              end
+              .to_s
+              .chomp
+
+          expect(diff).to eq(expected_output)
+        end
+      end
+    end
+
+    context "when given two Data objects of different classes" do
+      let(:a) { SuperDiff::Test::Point.new(1, 2) }
+      let(:b) { Data.define(:one, :two).new(1, 2) }
+
+      it "raises" do
+        expect { SuperDiff.diff(a, b) }.to raise_error(
+          SuperDiff::Core::NoDifferAvailableError
+        )
+      end
+    end
+
+    context "when given a Data object and a hash" do
+      let(:a) { Data.define(:one, :two).new(1, 2) }
+      let(:b) { { one: 1, two: 2 } }
+
+      it "raises" do
+        expect { SuperDiff.diff(a, b) }.to raise_error(
+          SuperDiff::Core::NoDifferAvailableError
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes #252.

Ruby 3.2.0 introduced the [Data](https://bugs.ruby-lang.org/issues/16122) construct, which looks a lot like an object to this project, but uses `#members` instead of instance variables.

The solution is to introduce an object inspection tree builder and operation tree builder that are essentially the same as the corresponding builders for default objects, but know to read the members of the Data class instead of instance variables.