### PR TITLE
Add String to primitive list

### DIFF
--- a/lib/super_diff.rb
+++ b/lib/super_diff.rb
@@ -113,7 +113,7 @@ module SuperDiff
 
   def self.primitive?(value)
     case value
-    when true, false, nil, Symbol, Numeric, Regexp, Class
+    when true, false, nil, Symbol, Numeric, Regexp, Class, String
       true
     else
       false

--- a/lib/super_diff/basic/inspection_tree_builders/primitive.rb
+++ b/lib/super_diff/basic/inspection_tree_builders/primitive.rb
@@ -3,7 +3,7 @@ module SuperDiff
     module InspectionTreeBuilders
       class Primitive < Core::AbstractInspectionTreeBuilder
         def self.applies_to?(value)
-          SuperDiff.primitive?(value) || value.is_a?(::String)
+          SuperDiff.primitive?(value)
         end
 
         def call

--- a/lib/super_diff/equality_matchers/defaults.rb
+++ b/lib/super_diff/equality_matchers/defaults.rb
@@ -1,11 +1,11 @@
 module SuperDiff
   module EqualityMatchers
     DEFAULTS = [
-      Primitive,
       Array,
       Hash,
       MultilineString,
       SinglelineString,
+      Primitive,
       Default
     ].freeze
   end


### PR DESCRIPTION
`String` is considered a primitive for the purposes of inspection, but was excluded from the `SuperDiff.primitive?` helper in order to support custom multiline and single-line strings in that area of the codebase.

A simpler way of achieving the same result is to consider `String` to be a primitive everywhere, and give the custom string equality matchers higher precedence than the primitive equality matcher.