### PR TITLE
Improve inspection of Module

### DIFF
--- a/lib/super_diff.rb
+++ b/lib/super_diff.rb
@@ -113,7 +113,7 @@ module SuperDiff
 
   def self.primitive?(value)
     case value
-    when true, false, nil, Symbol, Numeric, Regexp, Class, String
+    when true, false, nil, Symbol, Numeric, Regexp, Class, Module, String
       true
     else
       false

--- a/spec/unit/super_diff_spec.rb
+++ b/spec/unit/super_diff_spec.rb
@@ -1128,10 +1128,7 @@ RSpec.describe SuperDiff, type: :unit do
       context "given as_lines: false" do
         it "returns the module's name" do
           string =
-            described_class.inspect_object(
-              SuperDiff::Test,
-              as_lines: false
-            )
+            described_class.inspect_object(SuperDiff::Test, as_lines: false)
           expect(string).to eq("SuperDiff::Test")
         end
       end

--- a/spec/unit/super_diff_spec.rb
+++ b/spec/unit/super_diff_spec.rb
@@ -1124,6 +1124,40 @@ RSpec.describe SuperDiff, type: :unit do
       end
     end
 
+    context "given a module" do
+      context "given as_lines: false" do
+        it "returns the module's name" do
+          string =
+            described_class.inspect_object(
+              SuperDiff::Test,
+              as_lines: false
+            )
+          expect(string).to eq("SuperDiff::Test")
+        end
+      end
+
+      context "given as_lines: true" do
+        it "returns the module's name as value" do
+          tiered_lines =
+            described_class.inspect_object(
+              SuperDiff::Test,
+              as_lines: true,
+              type: :delete,
+              indentation_level: 1
+            )
+          expect(tiered_lines).to match(
+            [
+              an_object_having_attributes(
+                type: :delete,
+                indentation_level: 1,
+                value: "SuperDiff::Test"
+              )
+            ]
+          )
+        end
+      end
+    end
+
     # TODO: Add when empty
     context "given a custom object" do
       context "containing only primitive values" do


### PR DESCRIPTION
A module's inspection (used e.g. generate a description of an RSpec example) has been improved to now include the module's name, which identifies the module better than the previous string.

Old: `#<Module:0x0000000107f7a0a0>`
New (e.g.): `SuperDiff::Test`.

The improvement declares a `Module` a `Primitive` (which is what has been used for a `Class` already).

Closes #255.


FYI: Most of the time was spent to get the specs run locally. See https://github.com/splitwise/super_diff/commit/24b8183acf64ca4f4559286bdb6ac4750e43716f.