### PR TITLE
Filter super_diff from rspec backtrace

### DIFF
--- a/lib/super_diff/rspec.rb
+++ b/lib/super_diff/rspec.rb
@@ -133,3 +133,5 @@ module SuperDiff
 end
 
 require_relative 'rspec/monkey_patches'
+
+RSpec.configuration.filter_gems_from_backtrace('super_diff')


### PR DESCRIPTION
Removes the `super_diff` lines from the backtrace as described in #265.