### PR TITLE
Fix CI: require logger before active_record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Other changes
+
+- Fix `logger` dependency issues in CI. [#277](https://github.com/splitwise/super_diff/pull/277)
+
 ## 0.15.0 - 2025-01-06
 
 ### Features

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ SuperDiff::CurrentBundle.instance.assert_appraisal!
 #---
 
 begin
+  require 'logger'
   require 'active_record'
 
   active_record_available = true


### PR DESCRIPTION
See https://github.com/rails/rails/pull/54264. ActiveSupport required `logger` implicitly through `concurrent-ruby`, which removed its own `logger` dependency in 1.3.5.