### PR TITLE
Drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -54,7 +54,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - "3.0"
           - "3.1"
           - "3.2"
           - "3.3"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,15 @@ Lint/SuppressedException:
     - 'spec/spec_helper.rb'
     - 'support/test_plan.rb'
 
+Naming/BlockForwarding:
+  EnforcedStyle: explicit
+
 Naming/FileName:
   Exclude:
     - 'lib/super_diff/rspec-rails.rb'
 
 Naming/VariableNumber:
   Enabled: false
+
+Style/ArgumentsForwarding:
+  UseAnonymousForwarding: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Breaking changes
+
+- Dropped support for Ruby 3.0, which reached EOL in April 2024. [#280](https://github.com/splitwise/super_diff/pull/280)
+
 ### Features
 
 - Add official Rails 7.1 support. [#278](https://github.com/splitwise/super_diff/pull/278)

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ for more on how to do that.
 ## Compatibility
 
 `super_diff` is [tested][gh-actions] to work with
-Ruby >= 3.x,
+Ruby >= 3.1,
 RSpec 3.x,
 and Rails >= 6.1.
 

--- a/super_diff.gemspec
+++ b/super_diff.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true',
     'source_code_uri' => 'https://github.com/splitwise/super_diff'
   }
-  s.required_ruby_version = '>= 3.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.files = %w[README.md super_diff.gemspec] + Dir['lib/**/*']
   s.executables = Dir['exe/**/*'].map { |f| File.basename(f) }


### PR DESCRIPTION
Ruby 3.0 reached EOL in April 2024.