### PR TITLE
Tweak sqlite3 and appraisal dependencies

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -14,28 +14,28 @@ appraisals = {
       instance_eval(&rails_dependencies)
 
       gem 'rails', '~> 6.1.0'
-      gem 'sqlite3', '~> 1.4.0', platform: %i[ruby mswin mingw]
+      gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw]
     end,
   rails_7_0:
     proc do
       instance_eval(&rails_dependencies)
 
       gem 'rails', '~> 7.0.0'
-      gem 'sqlite3', '~> 1.4.0', platform: %i[ruby mswin mingw]
+      gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw]
     end,
   rails_7_1:
     proc do
       instance_eval(&rails_dependencies)
 
       gem 'rails', '~> 7.1.0'
-      gem 'sqlite3', '~> 1.4.0', platform: %i[ruby mswin mingw]
+      gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw]
     end,
   rails_7_2:
     proc do
       instance_eval(&rails_dependencies)
 
       gem 'rails', '~> 7.2.0'
-      gem 'sqlite3', '~> 1.4.0', platform: %i[ruby mswin mingw]
+      gem 'sqlite3', '~> 1.4', platform: %i[ruby mswin mingw]
     end,
   rails_8_0:
     proc do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Fix `logger` dependency issues in CI. [#277](https://github.com/splitwise/super_diff/pull/277)
 - Updated permalink to rspec differ in README.md [#258](https://github.com/splitwise/super_diff/pull/276) by [@sealocal](https://github.com/sealocal)
+- Tweak `sqlite3` and `appraisal` dev dependencies. [#287](https://github.com/splitwise/super_diff/pull/287)
 
 ## 0.15.0 - 2025-01-06
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
-gem 'appraisal', github: 'thoughtbot/appraisal'
+gem 'appraisal', '~> 2.5'
 gem 'bundler-audit'
 gem 'childprocess'
 gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/thoughtbot/appraisal
-  revision: 24feeea4c5c1d2e7a5f95d053da61858c6bfb2b1
-  specs:
-    appraisal (2.5.0)
-      bundler
-      rake
-      thor (>= 0.14.0)
-
 PATH
   remote: .
   specs:
@@ -18,6 +9,10 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    appraisal (2.5.0)
+      bundler
+      rake
+      thor (>= 0.14.0)
     ast (2.4.2)
     attr_extras (7.1.0)
     bundler-audit (0.9.2)
@@ -91,7 +86,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  appraisal!
+  appraisal (~> 2.5)
   bundler-audit
   childprocess
   climate_control

--- a/gemfiles/no_rails_rspec_gte_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"

--- a/gemfiles/no_rails_rspec_gte_3_13.gemfile
+++ b/gemfiles/no_rails_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"

--- a/gemfiles/no_rails_rspec_lt_3_10.gemfile
+++ b/gemfiles/no_rails_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"

--- a/gemfiles/rails_6_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_6_1_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 6.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.12.0"
 gem "rspec-core", "3.12.0"
 gem "rspec-expectations", "3.12.3"

--- a/gemfiles/rails_6_1_rspec_gte_3_13.gemfile
+++ b/gemfiles/rails_6_1_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 6.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.13.0"
 gem "rspec-core", "3.13.0"
 gem "rspec-expectations", "3.13.0"

--- a/gemfiles/rails_6_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_6_1_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 6.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"
 

--- a/gemfiles/rails_7_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_7_0_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.0.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.12.0"
 gem "rspec-core", "3.12.0"
 gem "rspec-expectations", "3.12.3"

--- a/gemfiles/rails_7_0_rspec_gte_3_13.gemfile
+++ b/gemfiles/rails_7_0_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.0.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.13.0"
 gem "rspec-core", "3.13.0"
 gem "rspec-expectations", "3.13.0"

--- a/gemfiles/rails_7_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_7_0_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.0.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"
 

--- a/gemfiles/rails_7_1_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_7_1_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.12.0"
 gem "rspec-core", "3.12.0"
 gem "rspec-expectations", "3.12.3"

--- a/gemfiles/rails_7_1_rspec_gte_3_13.gemfile
+++ b/gemfiles/rails_7_1_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.13.0"
 gem "rspec-core", "3.13.0"
 gem "rspec-expectations", "3.13.0"

--- a/gemfiles/rails_7_1_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_7_1_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.1.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"
 

--- a/gemfiles/rails_7_2_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_7_2_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.2.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.12.0"
 gem "rspec-core", "3.12.0"
 gem "rspec-expectations", "3.12.3"

--- a/gemfiles/rails_7_2_rspec_gte_3_13.gemfile
+++ b/gemfiles/rails_7_2_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.2.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "3.13.0"
 gem "rspec-core", "3.13.0"
 gem "rspec-expectations", "3.13.0"

--- a/gemfiles/rails_7_2_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_7_2_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"
@@ -19,7 +19,7 @@ gem "jdbc-sqlite3", platform: :jruby
 gem "net-ftp"
 gem "combustion"
 gem "rails", "~> 7.2.0"
-gem "sqlite3", "~> 1.4.0", platform: [:ruby, :mswin, :mingw]
+gem "sqlite3", "~> 1.4", platform: [:ruby, :mswin, :mingw]
 gem "rspec", "~> 3.9.0"
 gem "rspec-rails"
 

--- a/gemfiles/rails_8_0_rspec_gte_3_10.gemfile
+++ b/gemfiles/rails_8_0_rspec_gte_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"

--- a/gemfiles/rails_8_0_rspec_gte_3_13.gemfile
+++ b/gemfiles/rails_8_0_rspec_gte_3_13.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"

--- a/gemfiles/rails_8_0_rspec_lt_3_10.gemfile
+++ b/gemfiles/rails_8_0_rspec_lt_3_10.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "appraisal", git: "https://github.com/thoughtbot/appraisal"
+gem "appraisal", "~> 2.5"
 gem "bundler-audit"
 gem "childprocess"
 gem "climate_control"


### PR DESCRIPTION
- `sqlite3` 1.4.x wasn't compiling on my machine; I see no reason to keep it pinned to 1.4.x, so am relaxing that
- I happened to see that `appraisals` was pointed to the bleeding edge on Thoughtbot's Github repo; I'm reverting that to the latest `~> 2.5` stable release.