### PR TITLE
Fix failure case for chained matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix ActiveRecord's `attributes_for_super_diff` and tree builders related to Active Records to handle models that do not have a primary key.
   [#282](https://github.com/splitwise/super_diff/pull/282) by [@atranson-electra](https://github.com/atranson-electra)
+- Fix failure case for chained matchers. [#288](https://github.com/splitwise/super_diff/pull/288)
 
 ### Other changes
 

--- a/docs/contributors/architecture/how-super-diff-works.md
+++ b/docs/contributors/architecture/how-super-diff-works.md
@@ -39,7 +39,8 @@ or when a matcher whose `#does_not_match?` method returns `true`
 is passed to `expect(...).not_to` —
 RSpec will call the `RSpec::Expectations::ExpectationHelper#handle_failure` method,
 which will call `RSpec::Expectations.fail_with`.
-This method will use `RSpec::Matchers::ExpectedsForMultipleDiffs`
+This method will use `RSpec::Matchers::MultiMatcherDiff`
+(or in RSpec < 3.13.0, `RSpec::Matchers::ExpectedsForMultipleDiffs`)
 and the differ object that `RSpec::Expectations.differ` returns
 to generate a diff,
 combining it with the failure message from the matcher,
@@ -89,7 +90,7 @@ Here are all of the places that SuperDiff patches RSpec:
   as it interferes with the previous patches)
 - `RSpec::Support::ObjectFormatter`
   (to use SuperDiff's object inspection logic)
-- `RSpec::Matchers::ExpectedsForMultipleDiffs`
+- `RSpec::Matchers::ExpectedsForMultipleDiffs` and `RSpec::Matchers::MultiMatcherDiff`
   (to add a key above the diff,
   add spacing around the diff,
   and colorize the word "Diff:")

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -423,6 +423,26 @@ module RSpec
             new([[expected, text, actual]])
           end
 
+          def for_many_matchers(matchers)
+            # Look for expected_for_diff and actual_for_diff if possible
+            diff_tuples = matchers.map do |m|
+              expected = if m.respond_to?(:expected_for_diff)
+                           m.expected_for_diff
+                         else
+                           m.expected
+                         end
+
+              actual = if m.respond_to?(:actual_for_diff)
+                         m.actual_for_diff
+                       else
+                         m.actual
+                       end
+              [expected, diff_label_for(m), actual]
+            end
+
+            new(diff_tuples)
+          end
+
           def colorizer
             RSpec::Core::Formatters::ConsoleCodes
           end

--- a/lib/super_diff/rspec/monkey_patches.rb
+++ b/lib/super_diff/rspec/monkey_patches.rb
@@ -352,6 +352,26 @@ module RSpec
             new([[expected, text]])
           end
 
+          def for_many_matchers(matchers)
+            # Look for expected_for_diff and actual_for_diff if possible
+            diff_tuples = matchers.map do |m|
+              expected = if m.respond_to?(:expected_for_diff)
+                           m.expected_for_diff
+                         else
+                           m.expected
+                         end
+
+              actual = if m.respond_to?(:actual_for_diff)
+                         m.actual_for_diff
+                       else
+                         m.actual
+                       end
+              [expected, diff_label_for(m), actual]
+            end
+
+            new(diff_tuples)
+          end
+
           def colorizer
             RSpec::Core::Formatters::ConsoleCodes
           end


### PR DESCRIPTION
Fixes #286.

SuperDiff overrides the built-in `RaiseError` matcher to [report that it is `diffable?`](https://github.com/splitwise/super_diff/blob/303a5f0d39008ec408d7ab87c5020bdb069558e4/lib/super_diff/rspec/monkey_patches.rb#L836) in most cases. RSpec accordingly [assumes](https://github.com/rspec/rspec/blame/a067137e8655e8ee5820a5ebf8ca89054aa9499b/rspec-expectations/lib/rspec/matchers/expecteds_for_multiple_diffs.rb#L37) that it defines `#expected`. This issue may have existed since [SuperDiff 0.2.0](https://github.com/splitwise/super_diff/commit/0c7210634158b802c8f2d13c8f8a4bf40b6688f6#diff-95eeb68cdb264bd5b96144f59ef69453acfbed67e571cb94d236008a4194217eR414-R416) and [RSpec 3.2.0](https://github.com/rspec/rspec-expectations/commit/709c8e71fba466aa06b39c4c64701f14dbb52c95#diff-4457c9afedb7030c9af041e6da43bfa3bb2a590b07cb7c64a118486446d3b300R49).

This PR monkey-patches the `#expected` assumption, much in the same way that we [already do](https://github.com/splitwise/super_diff/blob/8645b956aa1c43dbde50445b4b99f6fc9504a14a/lib/super_diff/rspec/monkey_patches.rb#L29-L34) for `#handle_failure`.