### PR TITLE
CI: Try to use bundler-cache everywhere

### DIFF
--- a/.github/workflows/super_diff.yml
+++ b/.github/workflows/super_diff.yml
@@ -29,9 +29,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          bundler-cache: true
-      - name: Install Ruby dependencies
-        run: bundle install
+          bundler-cache: true # `bundle install` and cache gems.
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
@@ -57,6 +55,7 @@ jobs:
           - "3.1"
           - "3.2"
           - "3.3"
+          - "3.4"
         rails_appraisal:
           - rails_6_1
           - rails_7_0
@@ -71,6 +70,10 @@ jobs:
         exclude:
         - ruby: "3.1"
           rails_appraisal: "rails_8_0"
+        - ruby: "3.4"
+          rails_appraisal: "rails_6_1"
+        - ruby: "3.4"
+          rails_appraisal: "rails_7_0"
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.rails_appraisal }}_${{ matrix.rspec_appraisal }}.gemfile
     steps:


### PR DESCRIPTION
This PR uses bundler-cache: true where it can, avoiding a manual bundle install step.