### PR TITLE
Add dependency version restrictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ pkg
 spec/examples.txt
 spec/internal
 tmp
+*.gem
 
 # Ignore Yarn stuff
 .pnp.*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,9 +2,9 @@ PATH
   remote: .
   specs:
     super_diff (0.18.0)
-      attr_extras (>= 6.2.4)
-      diff-lcs
-      patience_diff
+      attr_extras (>= 6.2.4, < 8)
+      diff-lcs (~> 1.5)
+      patience_diff (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -14,7 +14,7 @@ GEM
       rake
       thor (>= 0.14.0)
     ast (2.4.2)
-    attr_extras (7.1.0)
+    attr_extras (6.2.5)
     bundler-audit (0.9.2)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)

--- a/super_diff.gemspec
+++ b/super_diff.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.files = %w[README.md super_diff.gemspec] + Dir['lib/**/*']
   s.executables = Dir['exe/**/*'].map { |f| File.basename(f) }
 
-  s.add_dependency 'attr_extras', '>= 6.2.4'
-  s.add_dependency 'diff-lcs'
-  s.add_dependency 'patience_diff'
+  s.add_dependency 'attr_extras', '>= 6.2.4', '< 8'
+  s.add_dependency 'diff-lcs', '~> 1.5'
+  s.add_dependency 'patience_diff', '~> 1.2'
 end


### PR DESCRIPTION
`gem build` suggested we not use open-ended version constraints. Fair point. This constrains dependencies to known compatible major versions.