### PR TITLE
Fix integration snippet indentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove unused `syntax_tree` gems from development. [#297](https://github.com/splitwise/super_diff/pull/297)
 - Simplify tiered lines elider. [#302](https://github.com/splitwise/super_diff/pull/302)
 - Support elision for flat line trees. [#300](https://github.com/splitwise/super_diff/pull/300)
+- Fix integration snippet indentation. [#299](https://github.com/splitwise/super_diff/pull/299)
 
 ## 0.18.0 - 2025-12-05
 

--- a/spec/support/integration/test_programs/base.rb
+++ b/spec/support/integration/test_programs/base.rb
@@ -106,7 +106,7 @@ module SuperDiff
                   opt_before = RSpec::Expectations.configuration.on_potential_false_positives
                   begin
                     RSpec::Expectations.configuration.on_potential_false_positives = :nothing
-                #{reindent(code, level: 3)}
+              #{reindent(code, level: 3)}
                   ensure
                     RSpec::Expectations.configuration.on_potential_false_positives = opt_before
                   end


### PR DESCRIPTION
Fixes warning:

```
super_diff/tmp/integration_spec.rb:17: warning: mismatched indentations at 'end' with 'class' at 15
```