### PR TITLE
Add opt-in binary string diff support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Features
+
+- Add opt-in binary string diff support. [#301](https://github.com/splitwise/super_diff/pull/301) by [@gschlager](https://github.com/gschlager)
+
 ### Other changes
 
 - Add max major version constraints to dependencies. [#296](https://github.com/splitwise/super_diff/pull/296)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,17 @@ you'd get this instead:
 
 [user-docs]: ./docs/users/getting-started.md
 
+### Optional Extensions
+
+If you need diffs for binary strings (`Encoding::ASCII_8BIT`),
+require the binary string integration:
+
+```ruby
+require "super_diff/binary_string"
+```
+
+This enables hex-dump diffs and keeps binary data out of the expectation text.
+
 ## Support
 
 My goal for this library is to improve your development experience.

--- a/docs/users/getting-started.md
+++ b/docs/users/getting-started.md
@@ -86,6 +86,18 @@ such as matchers.
 
 You can now continue on to [customizing SuperDiff](./customization.md).
 
+## Binary Strings
+
+SuperDiff can diff binary strings (`Encoding::ASCII_8BIT`) using a hex-dump
+format and a binary-safe inspection label.
+To enable this, add:
+
+```ruby
+require "super_diff/binary_string"
+```
+
+You can create binary strings with `String#b` or by forcing the encoding.
+
 ## Using parts of SuperDiff directly
 
 Although SuperDiff is primarily designed to integrate with RSpec,

--- a/lib/super_diff/binary_string.rb
+++ b/lib/super_diff/binary_string.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'super_diff/binary_string/differs'
+require 'super_diff/binary_string/inspection_tree_builders'
+require 'super_diff/binary_string/operation_trees'
+require 'super_diff/binary_string/operation_tree_builders'
+require 'super_diff/binary_string/operation_tree_flatteners'
+
+module SuperDiff
+  module BinaryString
+    def self.applies_to?(*values)
+      values.all? { |value| value.is_a?(::String) && value.encoding == Encoding::ASCII_8BIT }
+    end
+
+    SuperDiff.configure do |config|
+      config.prepend_extra_differ_classes(Differs::BinaryString)
+      config.prepend_extra_operation_tree_builder_classes(
+        OperationTreeBuilders::BinaryString
+      )
+      config.prepend_extra_operation_tree_classes(
+        OperationTrees::BinaryString
+      )
+      config.prepend_extra_inspection_tree_builder_classes(
+        InspectionTreeBuilders::BinaryString
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string.rb
+++ b/lib/super_diff/binary_string.rb
@@ -14,12 +14,6 @@ module SuperDiff
 
     SuperDiff.configure do |config|
       config.prepend_extra_differ_classes(Differs::BinaryString)
-      config.prepend_extra_operation_tree_builder_classes(
-        OperationTreeBuilders::BinaryString
-      )
-      config.prepend_extra_operation_tree_classes(
-        OperationTrees::BinaryString
-      )
       config.prepend_extra_inspection_tree_builder_classes(
         InspectionTreeBuilders::BinaryString
       )

--- a/lib/super_diff/binary_string/differs.rb
+++ b/lib/super_diff/binary_string/differs.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module Differs
+      autoload(
+        :BinaryString,
+        'super_diff/binary_string/differs/binary_string'
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string/differs/binary_string.rb
+++ b/lib/super_diff/binary_string/differs/binary_string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module Differs
+      class BinaryString < Core::AbstractDiffer
+        def self.applies_to?(expected, actual)
+          SuperDiff::BinaryString.applies_to?(expected, actual)
+        end
+
+        protected
+
+        def operation_tree_builder_class
+          OperationTreeBuilders::BinaryString
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/binary_string/inspection_tree_builders.rb
+++ b/lib/super_diff/binary_string/inspection_tree_builders.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module InspectionTreeBuilders
+      autoload(
+        :BinaryString,
+        'super_diff/binary_string/inspection_tree_builders/binary_string'
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string/inspection_tree_builders/binary_string.rb
+++ b/lib/super_diff/binary_string/inspection_tree_builders/binary_string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module InspectionTreeBuilders
+      class BinaryString < Core::AbstractInspectionTreeBuilder
+        def self.applies_to?(value)
+          SuperDiff::BinaryString.applies_to?(value)
+        end
+
+        def call
+          Core::InspectionTree.new do |t|
+            t.add_text "<binary string (#{object.bytesize} bytes)>"
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_tree_builders.rb
+++ b/lib/super_diff/binary_string/operation_tree_builders.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTreeBuilders
+      autoload(
+        :BinaryString,
+        'super_diff/binary_string/operation_tree_builders/binary_string'
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_tree_builders/binary_string.rb
+++ b/lib/super_diff/binary_string/operation_tree_builders/binary_string.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTreeBuilders
+      class BinaryString < Basic::OperationTreeBuilders::MultilineString
+        BYTES_PER_LINE = 16
+        private_constant :BYTES_PER_LINE
+
+        def self.applies_to?(expected, actual)
+          SuperDiff::BinaryString.applies_to?(expected, actual)
+        end
+
+        def initialize(*args)
+          args.first[:expected] = binary_to_hex(args.first[:expected])
+          args.first[:actual] = binary_to_hex(args.first[:actual])
+
+          super
+        end
+
+        protected
+
+        def build_operation_tree
+          OperationTrees::BinaryString.new([])
+        end
+
+        # Prevent creation of BinaryOperation objects which the flattener
+        # cannot handle
+        def should_compare?(_operation, _next_operation)
+          false
+        end
+
+        private
+
+        def split_into_lines(string)
+          super.map { |line| line.delete_suffix("\n") }.reject(&:empty?)
+        end
+
+        def binary_to_hex(data)
+          data
+            .each_byte
+            .each_slice(BYTES_PER_LINE)
+            .with_index
+            .map { |bytes, index| format_hex_line(index * BYTES_PER_LINE, bytes) }
+            .join("\n")
+        end
+
+        def format_hex_line(offset, bytes)
+          hex_pairs = bytes
+                      .map { |b| format('%02x', b) }
+                      .each_slice(2)
+                      .map(&:join)
+                      .join(' ')
+
+          ascii = bytes.map { |b| printable_char(b) }.join
+
+          format('%<offset>08x: %<hex>-39s  %<ascii>s', offset:, hex: hex_pairs, ascii:)
+        end
+
+        def printable_char(byte)
+          byte >= 32 && byte < 127 ? byte.chr : '.'
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_tree_builders/binary_string.rb
+++ b/lib/super_diff/binary_string/operation_tree_builders/binary_string.rb
@@ -24,12 +24,6 @@ module SuperDiff
           OperationTrees::BinaryString.new([])
         end
 
-        # Prevent creation of BinaryOperation objects which the flattener
-        # cannot handle
-        def should_compare?(_operation, _next_operation)
-          false
-        end
-
         private
 
         def split_into_lines(string)

--- a/lib/super_diff/binary_string/operation_tree_flatteners.rb
+++ b/lib/super_diff/binary_string/operation_tree_flatteners.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTreeFlatteners
+      autoload(
+        :BinaryString,
+        'super_diff/binary_string/operation_tree_flatteners/binary_string'
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_tree_flatteners/binary_string.rb
+++ b/lib/super_diff/binary_string/operation_tree_flatteners/binary_string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTreeFlatteners
+      class BinaryString < Core::AbstractOperationTreeFlattener
+        def build_tiered_lines
+          operation_tree.map do |operation|
+            Core::Line.new(
+              type: operation.name,
+              indentation_level: indentation_level,
+              value: operation.value
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_trees.rb
+++ b/lib/super_diff/binary_string/operation_trees.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTrees
+      autoload(
+        :BinaryString,
+        'super_diff/binary_string/operation_trees/binary_string'
+      )
+    end
+  end
+end

--- a/lib/super_diff/binary_string/operation_trees/binary_string.rb
+++ b/lib/super_diff/binary_string/operation_trees/binary_string.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module SuperDiff
+  module BinaryString
+    module OperationTrees
+      class BinaryString < Core::AbstractOperationTree
+        def self.applies_to?(value)
+          SuperDiff::BinaryString.applies_to?(value)
+        end
+
+        protected
+
+        def operation_tree_flattener_class
+          OperationTreeFlatteners::BinaryString
+        end
+      end
+    end
+  end
+end

--- a/lib/super_diff/rspec/differ.rb
+++ b/lib/super_diff/rspec/differ.rb
@@ -42,8 +42,14 @@ module SuperDiff
       end
 
       def comparing_singleline_strings?
+        return false if comparing_binary_strings?
+
         expected.is_a?(String) && actual.is_a?(String) &&
           !expected.include?("\n") && !actual.include?("\n")
+      end
+
+      def comparing_binary_strings?
+        defined?(BinaryString) && BinaryString.applies_to?(expected, actual)
       end
 
       def helpers

--- a/spec/integration/rspec/binary_string_spec.rb
+++ b/spec/integration/rspec/binary_string_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'super_diff/binary_string'
+
+RSpec.describe 'Integration with binary strings', type: :integration do
+  context 'when comparing two different binary strings' do
+    it 'produces the correct failure message' do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          require 'super_diff/binary_string'
+          actual = "Hello".b
+          expected = "World".b
+          expect(actual).to eq(expected)
+        TEST
+        program =
+          make_plain_test_program(snippet, color_enabled: color_enabled)
+
+        expected_output =
+          build_expected_output(
+            color_enabled: color_enabled,
+            snippet: 'expect(actual).to eq(expected)',
+            expectation:
+              proc do
+                line do
+                  plain 'Expected '
+                  actual '<binary string (5 bytes)>'
+                  plain ' to eq '
+                  expected '<binary string (5 bytes)>'
+                  plain '.'
+                end
+              end,
+            diff:
+              proc do
+                expected_line '- 00000000: 576f 726c 64                             World'
+                actual_line '+ 00000000: 4865 6c6c 6f                             Hello'
+              end
+          )
+
+        expect(program).to produce_output_when_run(expected_output).in_color(
+          color_enabled
+        )
+      end
+    end
+  end
+
+  context 'when comparing binary strings spanning multiple lines' do
+    it 'produces a multi-line hex dump diff' do
+      as_both_colored_and_uncolored do |color_enabled|
+        snippet = <<~TEST.strip
+          require 'super_diff/binary_string'
+          actual = ("A" * 20).b
+          expected = ("A" * 16 + "B" * 4).b
+          expect(actual).to eq(expected)
+        TEST
+        program =
+          make_plain_test_program(snippet, color_enabled: color_enabled)
+
+        expected_output =
+          build_expected_output(
+            color_enabled: color_enabled,
+            snippet: 'expect(actual).to eq(expected)',
+            expectation:
+              proc do
+                line do
+                  plain 'Expected '
+                  actual '<binary string (20 bytes)>'
+                  plain ' to eq '
+                  expected '<binary string (20 bytes)>'
+                  plain '.'
+                end
+              end,
+            diff:
+              proc do
+                plain_line '  00000000: 4141 4141 4141 4141 4141 4141 4141 4141  AAAAAAAAAAAAAAAA'
+                expected_line '- 00000010: 4242 4242                                BBBB'
+                actual_line '+ 00000010: 4141 4141                                AAAA'
+              end
+          )
+
+        expect(program).to produce_output_when_run(expected_output).in_color(
+          color_enabled
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/binary_string/inspection_tree_builders/binary_string_spec.rb
+++ b/spec/unit/binary_string/inspection_tree_builders/binary_string_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'super_diff/binary_string'
+
+RSpec.describe SuperDiff::BinaryString::InspectionTreeBuilders::BinaryString do
+  describe '#call' do
+    it 'renders byte counts for binary strings' do
+      [
+        ['Hello World!'.b, 12],
+        [''.b, 0],
+        ["\xff\xfe\x00\x01".b, 4]
+      ].each do |value, bytes|
+        tree = described_class.call(value)
+        result = tree.render_to_string(object: value)
+        expect(result).to eq("<binary string (#{bytes} bytes)>")
+      end
+    end
+  end
+end

--- a/spec/unit/binary_string/operation_tree_builders/binary_string_spec.rb
+++ b/spec/unit/binary_string/operation_tree_builders/binary_string_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'super_diff/binary_string'
+
+RSpec.describe SuperDiff::BinaryString::OperationTreeBuilders::BinaryString,
+               type: :unit do
+  describe 'hex dump format (xxd style)' do
+    subject(:operations) do
+      described_class.call(expected: expected, actual: actual)
+    end
+
+    # These tests verify output matches xxd format:
+    #   $ printf 'Hello World' | xxd
+    #   00000000: 4865 6c6c 6f20 576f 726c 64              Hello World
+    #
+    #   $ printf 'The quick brown fox jumps over the lazy dog.' | xxd
+    #   00000000: 5468 6520 7175 6963 6b20 6272 6f77 6e20  The quick brown
+    #   00000010: 666f 7820 6a75 6d70 7320 6f76 6572 2074  fox jumps over t
+    #   00000020: 6865 206c 617a 7920 646f 672e            he lazy dog.
+
+    context 'with a single line of data (xxd format verification)' do
+      let(:expected) { 'Hello World'.b }
+      let(:actual) { 'Hello World'.b }
+
+      it 'matches xxd output format exactly' do
+        expect(operations.first.value).to eq(
+          '00000000: 4865 6c6c 6f20 576f 726c 64              Hello World'
+        )
+      end
+    end
+
+    context 'with multiple lines of data (xxd format verification)' do
+      let(:expected) { 'The quick brown fox jumps over the lazy dog.'.b }
+      let(:actual) { 'The quick brown fox jumps over the lazy dog.'.b }
+
+      it 'matches xxd output format exactly' do
+        ops = operations.to_a
+        expect(ops[0].value).to eq(
+          '00000000: 5468 6520 7175 6963 6b20 6272 6f77 6e20  The quick brown '
+        )
+        expect(ops[1].value).to eq(
+          '00000010: 666f 7820 6a75 6d70 7320 6f76 6572 2074  fox jumps over t'
+        )
+        expect(ops[2].value).to eq(
+          '00000020: 6865 206c 617a 7920 646f 672e            he lazy dog.'
+        )
+      end
+    end
+
+    context 'with binary data containing non-printable characters' do
+      let(:expected) { "\x00\x01\x41\xff\xfe".b }
+      let(:actual) { "\x00\x01\x41\xff\xfe".b }
+
+      it 'formats non-printable characters as dots and preserves printable ones' do
+        expect(operations.first.value).to eq(
+          '00000000: 0001 41ff fe                             ..A..'
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/binary_string/operation_tree_flatteners/binary_string_spec.rb
+++ b/spec/unit/binary_string/operation_tree_flatteners/binary_string_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'super_diff/binary_string'
+
+RSpec.describe SuperDiff::BinaryString::OperationTreeFlatteners::BinaryString do
+  it 'returns a series of lines from printing each value' do
+    collection = Array.new(3) { :some_value }
+    cases = [
+      {
+        operations: [],
+        expected: []
+      },
+      {
+        operations: [
+          operation_double(
+            collection,
+            name: :noop,
+            value: '00000000: 4865 6c6c 6f                             Hello',
+            index: 0
+          ),
+          operation_double(
+            collection,
+            name: :noop,
+            value: '00000010: 576f 726c 64                             World',
+            index: 1
+          )
+        ],
+        expected: [
+          line_matcher(
+            type: :noop,
+            value: '00000000: 4865 6c6c 6f                             Hello'
+          ),
+          line_matcher(
+            type: :noop,
+            value: '00000010: 576f 726c 64                             World'
+          )
+        ]
+      },
+      {
+        operations: [
+          operation_double(
+            collection,
+            name: :noop,
+            value: '00000000: 4865 6c6c 6f                             Hello',
+            index: 0
+          ),
+          operation_double(
+            collection,
+            name: :delete,
+            value: '00000010: 4141 4141 41                             AAAAA',
+            index: 1
+          ),
+          operation_double(
+            collection,
+            name: :insert,
+            value: '00000010: 4242 4242 42                             BBBBB',
+            index: 1
+          )
+        ],
+        expected: [
+          line_matcher(
+            type: :noop,
+            value: '00000000: 4865 6c6c 6f                             Hello'
+          ),
+          line_matcher(
+            type: :delete,
+            value: '00000010: 4141 4141 41                             AAAAA'
+          ),
+          line_matcher(
+            type: :insert,
+            value: '00000010: 4242 4242 42                             BBBBB'
+          )
+        ]
+      }
+    ]
+
+    cases.each do |spec|
+      operation_tree =
+        SuperDiff::BinaryString::OperationTrees::BinaryString.new(
+          spec[:operations]
+        )
+      flattened_operation_tree = described_class.call(operation_tree)
+
+      expect(flattened_operation_tree).to match(spec[:expected])
+    end
+  end
+
+  def operation_double(collection, name:, value:, index:)
+    double(
+      :operation,
+      name: name,
+      collection: collection,
+      value: value,
+      index: index
+    )
+  end
+
+  def line_matcher(type:, value:)
+    an_object_having_attributes(
+      type: type,
+      indentation_level: 0,
+      prefix: '',
+      value: value,
+      add_comma: false
+    )
+  end
+end


### PR DESCRIPTION
Depends on https://github.com/splitwise/super_diff/pull/300

Add a `SuperDiff::BinaryString` extension that renders `ASCII-8BIT` strings as hex dumps. Users opt-in by requiring the module:

```
require 'super_diff/binary_string'
```

Includes a dedicated differ, inspection tree builder, operation tree builder/tree/flattener, and updates SuperDiff::RSpec::Differ to allow diffs for binary strings (skipping the single-line string short-
circuit).

Hex dumps use 16 bytes per line with offset, hex pairs, and ASCII representation (xxd-style output).
