### PR TITLE
Simplify tiered lines elider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add max major version constraints to dependencies. [#296](https://github.com/splitwise/super_diff/pull/296)
 - Remove unused `syntax_tree` gems from development. [#297](https://github.com/splitwise/super_diff/pull/297)
+- Simplify tiered lines elider. [#302](https://github.com/splitwise/super_diff/pull/302)
 
 ## 0.18.0 - 2025-12-05
 

--- a/lib/super_diff/core/tiered_lines_elider.rb
+++ b/lib/super_diff/core/tiered_lines_elider.rb
@@ -153,15 +153,22 @@ module SuperDiff
       end
 
       def filter_out_boxes_fully_contained_in_others(boxes)
-        sorted_boxes =
-          boxes.sort_by do |box|
-            [box.indentation_level, box.range.begin, box.range.end]
-          end
+        # First, sorts boxes by beginning ascending, range descending. (Boxes may
+        # never share beginnings, so the latter may be useless, but this is at least
+        # sufficient if unnecessary.)
+        #
+        # Then, iterate through each box, keeping track of the farthest "end" of any
+        # box seen so far. If the current box we are on ends before (or on) that farthest
+        # end, we know there is some box earlier in the sequence that begins <= this one
+        # (because of the prior sorting), and ends >= this one; that is, the current box
+        # is fully contained, and we can filter it out.
+        sorted = boxes.sort_by { |box| [box.range.begin, -box.range.end] }
+        max_end = -1
 
-        boxes.reject do |box2|
-          sorted_boxes.any? do |box1|
-            !box1.equal?(box2) && box1.fully_contains?(box2)
-          end
+        sorted.reject do |box|
+          contained = box.range.end <= max_end
+          max_end = box.range.end if box.range.end > max_end
+          contained
         end
       end
 

--- a/lib/super_diff/core/tiered_lines_elider.rb
+++ b/lib/super_diff/core/tiered_lines_elider.rb
@@ -46,11 +46,7 @@ module SuperDiff
 
       def padded_dirty_panes
         @padded_dirty_panes ||=
-          combine_congruent_panes(
-            dirty_panes
-              .map(&:padded)
-              .map { |pane| pane.capped_to(0, lines.size - 1) }
-          )
+          combine_congruent_panes(dirty_panes)
       end
 
       def dirty_panes
@@ -346,19 +342,6 @@ module SuperDiff
 
         def extended_to(new_end)
           self.class.new(type: type, range: range.begin..new_end)
-        end
-
-        def padded
-          self.class.new(type: type, range: Range.new(range.begin, range.end))
-        end
-
-        def capped_to(beginning, ending)
-          new_beginning = [range.begin, beginning].max
-          new_ending = [range.end, ending].min
-          self.class.new(
-            type: type,
-            range: Range.new(new_beginning, new_ending)
-          )
         end
       end
 

--- a/lib/super_diff/core/tiered_lines_elider.rb
+++ b/lib/super_diff/core/tiered_lines_elider.rb
@@ -41,12 +41,7 @@ module SuperDiff
 
       def panes
         @panes ||=
-          BuildPanes.call(dirty_panes: padded_dirty_panes, lines: lines)
-      end
-
-      def padded_dirty_panes
-        @padded_dirty_panes ||=
-          combine_congruent_panes(dirty_panes)
+          BuildPanes.call(dirty_panes: dirty_panes, lines: lines)
       end
 
       def dirty_panes
@@ -172,10 +167,6 @@ module SuperDiff
 
       def combine_congruent_boxes(boxes)
         combine(boxes, on: :indentation_level)
-      end
-
-      def combine_congruent_panes(panes)
-        combine(panes, on: :type)
       end
 
       def combine(spannables, on:)


### PR DESCRIPTION
While reviewing #300, I noticed some unrelated clean-up opportunities in `TieredLinesElider`.

Most importantly, `Pane#padded` was essentially a no-op. This PR gets rid of it, and simplifies up the call stack through `TieredLinesElider#panes`.

Less importantly, and more for my own satisfaction, `#filter_out_boxes_fully_contained_in_others` was $O(n^2)$; assuming sorting is sub-quadratic, it's also now sub-quadratic.