### PR TITLE
Remove indentation level special-casing in TieredLinesElider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix integration snippet indentation. [#299](https://github.com/splitwise/super_diff/pull/299) by [@gschlager](https://github.com/gschlager)
 - Pin all actions to full commit SHA. [#305](https://github.com/splitwise/super_diff/pull/305)
 - Do not attempt to sub-diff multiline strings. [#304](https://github.com/splitwise/super_diff/pull/304)
+- Tweak TieredLinesElider. [#307](https://github.com/splitwise/super_diff/pull/307)
 
 ## 0.18.0 - 2025-12-05
 

--- a/lib/super_diff/core/tiered_lines_elider.rb
+++ b/lib/super_diff/core/tiered_lines_elider.rb
@@ -99,8 +99,10 @@ module SuperDiff
       end
 
       def all_indentation_levels
-        levels = lines.map(&:indentation_level).uniq
-        normalized_indentation_levels(levels)
+        lines
+          .reject(&:complete_bookend?)
+          .map(&:indentation_level)
+          .uniq
       end
 
       def find_boxes_to_elide_within(pane)
@@ -137,8 +139,7 @@ module SuperDiff
 
         levels = boxes_within_pane.map(&:indentation_level).uniq
 
-        possible_indentation_levels =
-          normalized_indentation_levels(levels).sort.reverse
+        possible_indentation_levels = levels.sort.reverse
 
         possible_indentation_levels.map do |indentation_level|
           boxes_within_pane.select do |box|
@@ -165,14 +166,6 @@ module SuperDiff
           max_end = box.range.end if box.range.end > max_end
           contained
         end
-      end
-
-      def normalized_indentation_levels(levels)
-        # For flat structures (strings), include level 0
-        return levels if levels.all?(&:zero?)
-
-        # For nested structures (arrays, hashes), exclude level 0 (brackets)
-        levels.select(&:positive?)
       end
 
       def combine_congruent_boxes(boxes)

--- a/lib/super_diff/core/tiered_lines_elider.rb
+++ b/lib/super_diff/core/tiered_lines_elider.rb
@@ -131,7 +131,7 @@ module SuperDiff
       def normalized_box_groups_at_decreasing_indentation_levels_within(pane)
         box_groups_at_decreasing_indentation_levels_within(pane).map(
           &method(:filter_out_boxes_fully_contained_in_others)
-        ).map(&method(:combine_congruent_boxes))
+        ).map(&method(:combine_contiguous_boxes))
       end
 
       def box_groups_at_decreasing_indentation_levels_within(pane)
@@ -168,7 +168,7 @@ module SuperDiff
         end
       end
 
-      def combine_congruent_boxes(boxes)
+      def combine_contiguous_boxes(boxes)
         combine(boxes, on: :indentation_level)
       end
 


### PR DESCRIPTION
As [promised](https://github.com/splitwise/super_diff/pull/300#pullrequestreview-3800283677). Two minor changes:

First, in `#all_indentation_levels`, we were excluding bookends by inference: specifically, we assumed that if there were nonzero indentation levels, the lines with indentation level zero must be top-level bookends. We can just ask if `&:complete_bookend?` instead.

Second – and this one is more complicated – it turns out we don't need to exclude level 0 from `box_groups_at_decreasing_indentation_levels_within(pane)`. Why?

First, note that only clean panes are ever elided. Furthermore, we can assume that there is at least one dirty pane; otherwise, we [don't try to elide](https://github.com/splitwise/super_diff/blob/a14d17283fb9827db003f848be79c2003fac5e95/lib/super_diff/core/tiered_lines_elider.rb#L14).

Now: for a _top-level_ structure (no nesting), such as a multi-line string, we want to include level-0 boxes for elision. For _nested_ structures, we don't, because we don't want to elide the bookend symbols/lines, such as `{`/`}` for a Hash `[`/`]` for an Array, etc.

However, a level-0 box for a _nested_ structure necessarily spans the entire structure and therefore all lines; it starts with the open bookend and ends with the close bookend. And since there is at least one dirty pane, it's not possible for that level-0 box to fit within any given pane. Thus, level-0 boxes for nested structured will be [filtered out of `boxes_within_pane`](https://github.com/splitwise/super_diff/blob/a14d17283fb9827db003f848be79c2003fac5e95/lib/super_diff/core/tiered_lines_elider.rb#L138).

So, for nested structures, `possible_indentation_levels` will still exclude 0. For flat top-level structures, a top-level box would have been created for each top-level line, so it should still _include_ zero.